### PR TITLE
Project Integrations for Outgoing Webhooks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,4 @@ STORIES_CEILING=300
 CDN_URL=http://xpto.cloudfront.net
 FONT_ASSET=http://localhost
 NEW_RELIC_LICENSE_KEY=your_license_key
+INTEGRATION_URI_MATTERMOST=http://foo.com

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: codeminer42/ci-ruby:2.3
 
 services:
   - postgres:latest
+  - redis:latest
 
 cache:
   key: CM-Fulcrum

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 cache: bundler
+services:
+  - postgresql
+  - redis-server
 sudo: false
 env:
   - "DB=postgresql"

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group :development, :test do
   gem 'jasmine-rails', '~> 0.12.6'
-  gem 'phantomjs', '~> 2.1.1'
+  gem 'phantomjs', '~> 1.9'
   gem 'pry-rails'
   gem 'quiet_assets'
   gem 'sinon-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group :development, :test do
   gem 'jasmine-rails', '~> 0.12.6'
-  gem 'phantomjs', '~> 1.9'
+  gem 'phantomjs', '~> 2.1.1'
   gem 'pry-rails'
   gem 'quiet_assets'
   gem 'sinon-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
-    phantomjs (1.9.8.0)
+    phantomjs (2.1.1.0)
     pkg-config (1.1.7)
     poltergeist (1.10.0)
       capybara (~> 2.1)
@@ -352,7 +352,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   pg_search
-  phantomjs (~> 1.9)
+  phantomjs (~> 2.1.1)
   poltergeist
   pry-rails
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
-    phantomjs (2.1.1.0)
+    phantomjs (1.9.8.0)
     pkg-config (1.1.7)
     poltergeist (1.10.0)
       capybara (~> 2.1)
@@ -352,7 +352,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   pg_search
-  phantomjs (~> 2.1.1)
+  phantomjs (~> 1.9)
   poltergeist
   pry-rails
   puma

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -5,14 +5,12 @@ class IntegrationsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @integrations = @project.integrations
     @integration = Integration.new
-    respond_with(@integrations)
+    respond_with(@project.integrations)
   end
 
   def create
-    @integrations = @project.integrations
-    @integration = @integrations.build(kind: params[:integration][:kind]).tap do |i|
+    @integration = @project.integrations.build(kind: params[:integration][:kind]).tap do |i|
       i.data = JSON.parse params[:integration][:data]
     end
 

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,17 +1,16 @@
 class IntegrationsController < ApplicationController
   authorize_resource
+  before_action :load_project
 
   respond_to :html, :json
 
   def index
-    @project = current_user.projects.friendly.find(params[:project_id])
     @integrations = @project.integrations
     @integration = Integration.new
     respond_with(@integrations)
   end
 
   def create
-    @project = current_user.projects.friendly.find(params[:project_id])
     @integrations = @project.integrations
     @integration = @integrations.build(kind: params[:integration][:kind]).tap do |i|
       i.data = JSON.parse params[:integration][:data]
@@ -32,10 +31,15 @@ class IntegrationsController < ApplicationController
   end
 
   def destroy
-    @project = current_user.projects.friendly.find(params[:project_id])
     @integration = @project.integrations.find(params[:id])
     @project.integrations.delete(@integration)
     redirect_to project_integrations_url(@project)
+  end
+
+  private
+
+  def load_project
+    @project = current_user.projects.friendly.find(params[:project_id])
   end
 
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,0 +1,42 @@
+class IntegrationsController < ApplicationController
+  authorize_resource
+
+  respond_to :html, :json
+
+  def index
+    @project = current_user.projects.friendly.find(params[:project_id])
+    @integrations = @project.integrations
+    @integration = Integration.new
+    respond_with(@integrations)
+  end
+
+  def create
+    @project = current_user.projects.friendly.find(params[:project_id])
+    @integrations = @project.integrations
+    @integration = @integrations.build(kind: params[:integration][:kind]).tap do |i|
+      i.data = JSON.parse params[:integration][:data]
+    end
+
+    if @project.integrations.find_by(kind: @integration.kind)
+      flash[:alert] = "#{@integration.kind} is already configured for this project"
+    else
+      if @integration.save
+        flash[:notice] = "#{@integration.kind} was added to this project"
+      else
+        render 'index'
+        return
+      end
+    end
+
+    redirect_to project_integrations_url(@project)
+  end
+
+  def destroy
+    @project = current_user.projects.friendly.find(params[:project_id])
+    @integration = @project.integrations.find(params[:id])
+    @project.integrations.delete(@integration)
+    redirect_to project_integrations_url(@project)
+  end
+
+end
+

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -41,6 +41,7 @@ class ProjectsController < ApplicationController
   def edit
     @project = current_user.projects.friendly.find(params[:id])
     @project.users.build
+    @integration = Integration.new
   end
 
   # POST /projects

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -65,6 +65,7 @@ class ProjectsController < ApplicationController
   # PUT /projects/1.xml
   def update
     @project = current_user.projects.friendly.find(params[:id])
+    @integration = Integration.new
 
     respond_to do |format|
       if @project.update_attributes(allowed_params)

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -3,12 +3,20 @@ class Notifications < ActionMailer::Base
 
   delegate :name, to: :project, prefix: true
 
+  def started(story, owned_by)
+    @story = story
+    @owned_by = owned_by
+
+    mail :to => story.requested_by.email, :from => owned_by.email,
+      :subject => "[#{story.project.name}] Your story '#{story.title}' has been started."
+  end
+
   def delivered(story, delivered_by)
     @story = story
     @delivered_by = delivered_by
 
     mail :to => story.requested_by.email, :from => delivered_by.email,
-      :subject => "[#{story.project_name}] Your story '#{story.title}' has been delivered for acceptance."
+      :subject => "[#{story.project.name}] Your story '#{story.title}' has been delivered for acceptance."
   end
 
   def accepted(story, accepted_by)
@@ -16,7 +24,7 @@ class Notifications < ActionMailer::Base
     @accepted_by = accepted_by
 
     mail :to => story.owned_by.email, :from => accepted_by.email,
-      :subject => "[#{story.project_name}] #{accepted_by.name} ACCEPTED your story '#{story.title}'."
+      :subject => "[#{story.project.name}] #{accepted_by.name} ACCEPTED your story '#{story.title}'."
   end
 
   def rejected(story, rejected_by)
@@ -24,7 +32,7 @@ class Notifications < ActionMailer::Base
     @accepted_by = rejected_by
 
     mail :to => story.owned_by.email, :from => rejected_by.email,
-      :subject => "[#{story.project_name}] #{rejected_by.name} REJECTED your story '#{story.title}'."
+      :subject => "[#{story.project.name}] #{rejected_by.name} REJECTED your story '#{story.title}'."
   end
 
   # Send notification to of a new note to the listed users
@@ -35,13 +43,13 @@ class Notifications < ActionMailer::Base
     @notify_emails = notify_users.map(&:email)
 
     mail :to => @notify_emails, :from => @note.user.email,
-      :subject => "[#{@story.project_name}] New comment on '#{@story.title}'"
+      :subject => "[#{@story.project.name}] New comment on '#{@story.title}'"
   end
 
   def story_mention(story, users_to_notify)
     @story = story
 
     mail to: users_to_notify.map(&:email), from: @story.requested_by.email,
-      subject: "[#{@story.project_name}] New mention on '#{@story.title}'"
+      subject: "[#{@story.project.name}] New mention on '#{@story.title}'"
   end
 end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,0 +1,8 @@
+class Integration < ActiveRecord::Base
+  VALID_INTEGRATIONS = ['mattermost']
+
+  belongs_to :project
+  validates :project, presence: true
+  validates :kind, inclusion: { in: VALID_INTEGRATIONS }, presence: true
+  validates :data, presence: true
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,7 @@ class Project < ActiveRecord::Base
   validates_numericality_of :default_velocity, :greater_than => 0,
                             :only_integer => true
 
+  has_many :integrations, dependent: :destroy
   has_many :memberships, dependent: :destroy
   has_many :users, -> { uniq }, through: :memberships
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -78,6 +78,7 @@ class Project < ActiveRecord::Base
           tasks << "* #{value}" if header == 'Task' && value
         end
         story.description = "#{story.description}\n\nTasks:\n\n#{tasks.join("\n")}" unless tasks.empty?
+        story.project.suppress_notifications = true # otherwise the import will generate massive notifications!
         story.save
 
         # Generate notes for this story if any are present

--- a/app/models/story_observer.rb
+++ b/app/models/story_observer.rb
@@ -45,10 +45,6 @@ class StoryObserver < ActiveRecord::Observer
 
       end
 
-      # FIXME move this code to some other service that concentrates both sending email and pushing integrations
-      if notifier && story.project.integrations.count > 0
-      end
-
       # Set the project start date to today if the project start date is nil
       # and the state is changing to any state other than 'unstarted' or
       # 'unscheduled'

--- a/app/models/story_observer.rb
+++ b/app/models/story_observer.rb
@@ -9,6 +9,11 @@ class StoryObserver < ActiveRecord::Observer
         # Send a 'the story has been delivered' notification if the state has
         # changed to 'delivered'
         # FIXME Move to predicate on Story
+        if story.state == 'started' && story.acting_user && story.requested_by && story.requested_by.email_delivery? && story.acting_user != story.requested_by
+          notifier = Notifications.started(story, story.acting_user)
+          notifier.deliver if notifier
+        end
+
         if story.state == 'delivered' && story.acting_user && story.requested_by && story.requested_by.email_delivery? && story.acting_user != story.requested_by
           notifier = Notifications.delivered(story, story.acting_user)
           notifier.deliver if notifier

--- a/app/views/integrations/_form.html.erb
+++ b/app/views/integrations/_form.html.erb
@@ -1,0 +1,32 @@
+<% if @project.integrations.exists? %>
+  <h3>Integrations</h2>
+  <ul class="list-group members-list">
+    <% @project.integrations.each do |integration| %>
+      <li class="list-group-item clearfix">
+        <%= integration.kind %> - <%= integration.data %>
+        <%= link_to 'Remove', project_integration_path(@project, integration),
+        :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
+        :method => :delete,
+        class: 'btn btn-danger btn-sm pull-right' %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<h3>Add a new integration</h2>
+<div class="form-wrapper add-member">
+<%= form_for [@project, @integration] do |i| %>
+  <div class="field-wrapper">
+    <%= i.label :kind, class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10"><%= i.select :kind, Integration::VALID_INTEGRATIONS %></div>
+  </div>
+  <div class="field-wrapper">
+    <%= i.label :data, class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10"><%= i.text_field :data %>
+    <br/>ex: { "channel":"testing-mentions", "bot_username":"marvin", "private_uri":"https://mm42.com.br/hooks/private_token" }</div>
+  </div>
+  <div class="actions">
+    <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
+  </div>
+<% end %>
+</div>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title_bar do %>
+  <%= render :partial => 'projects/nav', :locals => {:project => @project} %>
+<% end %>
+
+<h2>Integrations</h2>
+<ul class="list-group members-list">
+  <% @project.integrations.each do |integration| %>
+    <li class="list-group-item clearfix">
+      <%= integration.kind %>
+      <%= link_to 'Remove', project_integration_path(@project, integration),
+      :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
+      :method => :delete,
+      class: 'btn btn-danger btn-sm pull-right' %>
+    </li>
+  <% end %>
+</ul>
+<h2>Add a new integration</h2>
+<div class="form-wrapper add-member">
+<%= form_for project_integrations_path(@project, @integration) do |f| %>
+  <% fields_for :integration do |i| %>
+    <div class="field-wrapper">
+      <%= i.label :email, class: 'col-sm-2 control-label' %>
+      <div class="col-sm-10"><%= i.text_field :kind %></div>
+    </div>
+    <div class="field-wrapper">
+      <%= i.label :data, class: 'col-sm-2 control-label' %>
+      <div class="col-sm-10"><%= i.text_field :data %></div>
+    </div>
+    <div class="actions">
+      <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
+    </div>
+  <% end %>
+<% end %>
+</div>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -2,34 +2,4 @@
   <%= render :partial => 'projects/nav', :locals => {:project => @project} %>
 <% end %>
 
-<% if @project.integrations.count > 0 %>
-<h2>Integrations</h2>
-<ul class="list-group members-list">
-  <% @project.integrations.each do |integration| %>
-    <li class="list-group-item clearfix">
-      <%= integration.kind %> - <%= integration.data %>
-      <%= link_to 'Remove', project_integration_path(@project, integration),
-      :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
-      :method => :delete,
-      class: 'btn btn-danger btn-sm pull-right' %>
-    </li>
-  <% end %>
-</ul>
-<% end %>
-<h2>Add a new integration</h2>
-<div class="form-wrapper add-member">
-<%= form_for [@project, @integration] do |i| %>
-  <div class="field-wrapper">
-    <%= i.label :kind, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= i.select :kind, Integration::VALID_INTEGRATIONS %></div>
-  </div>
-  <div class="field-wrapper">
-    <%= i.label :data, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= i.text_field :data %>
-    <br/>ex: { "channel":"testing-mentions", "bot_username":"marvin", "private_uri":"https://mm42.com.br/hooks/private_token" }</div>
-  </div>
-  <div class="actions">
-    <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
-  </div>
-<% end %>
-</div>
+<%= render 'form' %>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -2,11 +2,12 @@
   <%= render :partial => 'projects/nav', :locals => {:project => @project} %>
 <% end %>
 
+<% if @project.integrations.count > 0 %>
 <h2>Integrations</h2>
 <ul class="list-group members-list">
   <% @project.integrations.each do |integration| %>
     <li class="list-group-item clearfix">
-      <%= integration.kind %>
+      <%= integration.kind %> - <%= integration.data %>
       <%= link_to 'Remove', project_integration_path(@project, integration),
       :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
       :method => :delete,
@@ -14,21 +15,21 @@
     </li>
   <% end %>
 </ul>
+<% end %>
 <h2>Add a new integration</h2>
 <div class="form-wrapper add-member">
-<%= form_for project_integrations_path(@project, @integration) do |f| %>
-  <% fields_for :integration do |i| %>
-    <div class="field-wrapper">
-      <%= i.label :email, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10"><%= i.text_field :kind %></div>
-    </div>
-    <div class="field-wrapper">
-      <%= i.label :data, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10"><%= i.text_field :data %></div>
-    </div>
-    <div class="actions">
-      <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
-    </div>
-  <% end %>
+<%= form_for [@project, @integration] do |i| %>
+  <div class="field-wrapper">
+    <%= i.label :kind, class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10"><%= i.select :kind, Integration::VALID_INTEGRATIONS %></div>
+  </div>
+  <div class="field-wrapper">
+    <%= i.label :data, class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10"><%= i.text_field :data %>
+    <br/>ex: { "channel":"testing-mentions", "bot_username":"marvin", "private_uri":"https://mm42.com.br/hooks/private_token" }</div>
+  </div>
+  <div class="actions">
+    <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
+  </div>
 <% end %>
 </div>

--- a/app/views/notifications/started.text.erb
+++ b/app/views/notifications/started.text.erb
@@ -1,0 +1,14 @@
+<%= @owned_by.name %> has started your story '<%= @story.title %>'.
+
+<% if (@story.estimate.nil? || @story.estimate == 0) %>
+  <% if @story.story_type != 'feature' %>
+This is either a bug or a chore There is no estimation. Expect the sprint velocity to decrease.
+  <% else %>
+This story is NOT estimated. Ask <%= @owned_by.name %> to add proper estimation before implementation!
+  <% end %>
+<% else %>
+The estimation of this story is <%= @story.estimate %> points.
+<% end %>
+
+<%= project_url @story.project %>
+

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -44,35 +44,5 @@
 </div>
 
 <% unless @project.new_record? %>
-  <% if @project.integrations.count > 0 %>
-    <h2>Integrations</h2>
-    <ul class="list-group members-list">
-      <% @project.integrations.each do |integration| %>
-        <li class="list-group-item clearfix">
-          <%= integration.kind %> - <%= integration.data %>
-          <%= link_to 'Remove', project_integration_path(@project, integration),
-          :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
-          :method => :delete,
-          class: 'btn btn-danger btn-sm pull-right' %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
-  <h2>Add a new integration</h2>
-  <div class="form-wrapper add-member">
-  <%= form_for [@project, @integration] do |i| %>
-    <div class="field-wrapper">
-      <%= i.label :kind, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10"><%= i.select :kind, Integration::VALID_INTEGRATIONS %></div>
-    </div>
-    <div class="field-wrapper">
-      <%= i.label :data, class: 'col-sm-2 control-label' %>
-      <div class="col-sm-10"><%= i.text_field :data %>
-      <br/>ex: { "channel":"testing-mentions", "bot_username":"marvin", "private_uri":"https://mm42.com.br/hooks/private_token" }</div>
-    </div>
-    <div class="actions">
-      <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
-    </div>
-  <% end %>
-  </div>
+  <%= render 'integrations/form' %>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -44,34 +44,35 @@
 </div>
 
 <% unless @project.new_record? %>
-  <h2>Integrations</h2>
-  <ul class="list-group members-list">
-    <% @project.integrations.each do |integration| %>
-      <li class="list-group-item clearfix">
-        <%= integration.kind %>
-        <%= link_to 'Remove', project_integration_path(@project, integration),
-        :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
-        :method => :delete,
-        class: 'btn btn-danger btn-sm pull-right' %>
-      </li>
-    <% end %>
-  </ul>
+  <% if @project.integrations.count > 0 %>
+    <h2>Integrations</h2>
+    <ul class="list-group members-list">
+      <% @project.integrations.each do |integration| %>
+        <li class="list-group-item clearfix">
+          <%= integration.kind %> - <%= integration.data %>
+          <%= link_to 'Remove', project_integration_path(@project, integration),
+          :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
+          :method => :delete,
+          class: 'btn btn-danger btn-sm pull-right' %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
   <h2>Add a new integration</h2>
   <div class="form-wrapper add-member">
-  <%= form_for project_integrations_path(@project, @integration) do |f| %>
-    <% fields_for :integration do |i| %>
-      <div class="field-wrapper">
-        <%= i.label :email, class: 'col-sm-2 control-label' %>
-        <div class="col-sm-10"><%= i.text_field :kind %></div>
-      </div>
-      <div class="field-wrapper">
-        <%= i.label :data, class: 'col-sm-2 control-label' %>
-        <div class="col-sm-10"><%= i.text_field :data %></div>
-      </div>
-      <div class="actions">
-        <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
-      </div>
-    <% end %>
+  <%= form_for [@project, @integration] do |i| %>
+    <div class="field-wrapper">
+      <%= i.label :kind, class: 'col-sm-2 control-label' %>
+      <div class="col-sm-10"><%= i.select :kind, Integration::VALID_INTEGRATIONS %></div>
+    </div>
+    <div class="field-wrapper">
+      <%= i.label :data, class: 'col-sm-2 control-label' %>
+      <div class="col-sm-10"><%= i.text_field :data %>
+      <br/>ex: { "channel":"testing-mentions", "bot_username":"marvin", "private_uri":"https://mm42.com.br/hooks/private_token" }</div>
+    </div>
+    <div class="actions">
+      <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
+    </div>
   <% end %>
   </div>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -42,3 +42,36 @@
   </div>
 <% end %>
 </div>
+
+<% unless @project.new_record? %>
+  <h2>Integrations</h2>
+  <ul class="list-group members-list">
+    <% @project.integrations.each do |integration| %>
+      <li class="list-group-item clearfix">
+        <%= integration.kind %>
+        <%= link_to 'Remove', project_integration_path(@project, integration),
+        :confirm => "Are you sure you want to remove '#{integration.kind}' integration from this project?",
+        :method => :delete,
+        class: 'btn btn-danger btn-sm pull-right' %>
+      </li>
+    <% end %>
+  </ul>
+  <h2>Add a new integration</h2>
+  <div class="form-wrapper add-member">
+  <%= form_for project_integrations_path(@project, @integration) do |f| %>
+    <% fields_for :integration do |i| %>
+      <div class="field-wrapper">
+        <%= i.label :email, class: 'col-sm-2 control-label' %>
+        <div class="col-sm-10"><%= i.text_field :kind %></div>
+      </div>
+      <div class="field-wrapper">
+        <%= i.label :data, class: 'col-sm-2 control-label' %>
+        <div class="col-sm-10"><%= i.text_field :data %></div>
+      </div>
+      <div class="actions">
+        <%= i.submit 'Add integration', class: 'btn btn-primary pull-right' %>
+      </div>
+    <% end %>
+  <% end %>
+  </div>
+<% end %>

--- a/app/workers/integration_worker.rb
+++ b/app/workers/integration_worker.rb
@@ -1,0 +1,16 @@
+class IntegrationWorker
+  include Sidekiq::Worker
+
+  def perform(project_id, message)
+    project = Project.find(project_id)
+    project.integrations.each do |integration|
+      if integration.kind == 'mattermost'
+        Mattermost.send(integration.data['private_uri'],
+                        integration.data['channel'],
+                        integration.data['bot_username'],
+                        message)
+      end
+    end
+  end
+end
+

--- a/app/workers/integration_worker.rb
+++ b/app/workers/integration_worker.rb
@@ -5,11 +5,21 @@ class IntegrationWorker
     project = Project.find(project_id)
     project.integrations.each do |integration|
       if integration.kind == 'mattermost'
-        Mattermost.send(integration.data['private_uri'],
+        Mattermost.send(real_private_uri(integration.data['private_uri'] ),
                         integration.data['channel'],
                         integration.data['bot_username'],
                         message)
       end
+    end
+  end
+
+  private
+
+  def real_private_uri(private_uri)
+    if private_uri.starts_with? "INTEGRATION_URI"
+      ENV[private_uri]
+    else
+      private_uri
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,10 @@ module Fulcrum
       load Rails.root.join('config','fulcrum.rb')
     end
     config.fulcrum = ::Configuration.for 'fulcrum'
+
+    #FIXME this shouldn't be necessary in Rails 4 but the generator was falling back to test_unit
+    config.generators do |g|
+      g.test_framework :rspec
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,8 @@ module Fulcrum
 
     config.i18n.available_locales = ['de', 'el', 'en', 'es', 'nl', 'ja', 'pt-BR']
 
-    config.autoload_paths += %W(#{config.root}/lib/)
+    config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('lib/integrations')
 
     config.active_record.observers = :story_observer
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       get :search
     end
     resources :users, only: [:index, :create, :destroy]
+    resources :integrations, only: [:index, :create, :destroy]
     resources :changesets, only: [:index]
     resources :stories, only: [:index, :create, :update, :destroy, :show] do
       resources :notes, only: [:index, :create, :show, :destroy]

--- a/db/migrate/20160818013050_create_integrations.rb
+++ b/db/migrate/20160818013050_create_integrations.rb
@@ -1,0 +1,14 @@
+class CreateIntegrations < ActiveRecord::Migration
+  def change
+    enable_extension "hstore"
+
+    create_table :integrations do |t|
+      t.belongs_to :project, foreign_key: true
+      t.string :kind, null: false
+      t.hstore :data, null: false
+
+      t.timestamps
+    end
+    add_index  :integrations, :data, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160628195845) do
+ActiveRecord::Schema.define(version: 20160818013050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "attachinary_files", force: true do |t|
     t.integer  "attachinariable_id"
@@ -38,6 +39,16 @@ ActiveRecord::Schema.define(version: 20160628195845) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "integrations", force: true do |t|
+    t.integer  "project_id"
+    t.string   "kind",       null: false
+    t.hstore   "data",       null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "integrations", ["data"], name: "index_integrations_on_data", using: :gin
 
   create_table "memberships", force: true do |t|
     t.integer  "project_id"

--- a/lib/integrations/mattermost.rb
+++ b/lib/integrations/mattermost.rb
@@ -1,0 +1,26 @@
+require "net/http"
+require "uri"
+
+class Mattermost
+  def self.send(private_uri, project_channel, bot_username, message)
+    Mattermost.new(private_uri, project_channel, bot_username).send(message)
+  end
+
+  def initialize(private_uri, project_channel = "off-topic", bot_username = "marvin")
+    @private_uri = URI.parse(private_uri)
+    @project_channel = project_channel
+    @bot_username = bot_username
+  end
+
+  def send(text)
+    Net::HTTP.post_form(@private_uri, {"payload" => payload(text)})
+  end
+
+  def payload(text)
+    {
+      username: @bot_username,
+      channel: @project_channel,
+      text: text
+    }.to_json
+  end
+end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -42,7 +42,6 @@ describe IntegrationsController do
             get :index, :project_id => project.id
             expect(response).to be_success
             expect(assigns[:project]).to eq(project)
-            expect(assigns[:integrations].to_a).to eq([ integration ])
           end
         end
 
@@ -50,7 +49,7 @@ describe IntegrationsController do
           specify do
             xhr :get, :index, :project_id => project.id, :format => :json
             expect(response).to be_success
-            expect(response.body).to eq(assigns[:integrations].to_json)
+            expect(response.body.size).to eql([ integration ].to_json.size) # the integration.data hstore json can come up with fields in different orders
           end
 
         end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe IntegrationsController do
+
+  let(:integration) { FactoryGirl.build(:integration) }
+  let(:project) { integration.project }
+
+  context "when logged out" do
+    %w[index create].each do |action|
+      specify do
+        get action, :project_id => project.id
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+    %w[destroy].each do |action|
+      specify do
+        get action, :id => 42, :project_id => project.id
+        expect(response).to redirect_to(new_user_session_url)
+      end
+    end
+  end
+
+  context "when logged in" do
+
+    let(:user)  { FactoryGirl.create(:user) }
+    let(:projects)  { double("projects") }
+
+    before do
+      sign_in user
+      allow(subject).to receive_messages(:current_user => user)
+      allow(user).to receive_messages(:projects => projects)
+      allow(projects).to receive_message_chain(:friendly, :find).with(project.id.to_s) { project }
+    end
+
+    describe "collection actions" do
+
+      describe "#index" do
+        before { integration.save }
+
+        context "as html" do
+          specify do
+            get :index, :project_id => project.id
+            expect(response).to be_success
+            expect(assigns[:project]).to eq(project)
+            expect(assigns[:integrations].to_a).to eq([ integration ])
+          end
+        end
+
+        context "as json" do
+          specify do
+            xhr :get, :index, :project_id => project.id, :format => :json
+            expect(response).to be_success
+            expect(response.body).to eq(assigns[:integrations].to_json)
+          end
+
+        end
+
+      end
+
+      describe "#create" do
+
+        let(:integration_params) {{
+          "kind" => integration.kind,
+          "data" => integration.data.to_json
+        }}
+
+        specify do
+          expect {
+            post :create, :project_id => project.id, :integration => integration_params
+          }.to change { Integration.count }.by(1)
+          expect(assigns[:project]).to eq(project)
+          expect(assigns[:integration].kind).to eq(integration_params["kind"])
+          expect(assigns[:integration].data).to eq(JSON.parse integration_params["data"])
+          expect(response).to redirect_to(project_integrations_url(project))
+        end
+
+        context "when integration does not exist" do
+
+          context "when save fails" do
+            before {
+              integration_params[:kind] = nil
+            }
+
+            specify do
+              expect {
+                post :create, :project_id => project.id, :integration => integration_params
+              }.to change { Integration.count }.by(0)
+              expect(response).to render_template('index')
+            end
+
+          end
+
+          context "when save succeeds" do
+
+            specify do
+              post :create, :project_id => project.id, :integration => integration_params
+              expect(flash[:notice]).to eq("#{integration.kind} was added to this project")
+            end
+
+          end
+        end
+
+        context "when integration exists" do
+          before { integration.save }
+
+          specify do
+            expect {
+              post :create, :project_id => project.id, :integration => integration_params
+            }.to change { Integration.count }.by(0)
+            expect(flash[:alert]).to eq("#{integration.kind} is already configured for this project")
+          end
+        end
+      end
+    end
+
+    describe "integration actions" do
+      before { integration.save }
+
+      describe "#destroy" do
+
+        specify do
+          delete :destroy, :project_id => project.id, :id => integration.id
+          expect(response).to redirect_to(project_integrations_url(project))
+        end
+
+      end
+
+    end
+
+  end
+end
+

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,4 +52,10 @@ FactoryGirl.define do
     t.name 'Test task'
     t.association :story
   end
+
+  factory :integration do |i|
+    i.association :project
+    i.kind 'mattermost'
+    i.data ( { channel: 'test-channel', bot_username: 'marvin', private_uri: 'http://foo.com' } )
+  end
 end

--- a/spec/lib/integrations/mattermost_spec.rb
+++ b/spec/lib/integrations/mattermost_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Mattermost do
+  let(:mattermost) { Mattermost.new("http://foo.com", "test-channel", "bot")}
+
+  context '#payload' do
+    it 'returns a JSON formatted payload' do
+      expect(mattermost.payload("Hello World")).to eq("{\"username\":\"bot\",\"channel\":\"test-channel\",\"text\":\"Hello World\"}")
+    end
+  end
+
+  context '#send' do
+    it 'triggers a HTTP POST to send payload' do
+      expect(Net::HTTP).to receive(:post_form)
+      mattermost.send("hello")
+    end
+  end
+end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe Integration do
+
+  subject { FactoryGirl.build :integration }
+
+  describe "#project" do
+    it "cannot be nil" do
+      subject.project_id = nil
+      subject.valid?
+      expect(subject.errors[:project].size).to eq(1)
+    end
+
+    it "must have a valid project_id" do
+      subject.project_id = "invalid"
+      subject.valid?
+      expect(subject.errors[:project].size).to eq(1)
+    end
+
+    it "must have a project" do
+      subject.project =  nil
+      subject.valid?
+      expect(subject.errors[:project].size).to eq(1)
+    end
+  end
+
+  describe "#kind" do
+    it "should have a valid kind" do
+      subject.kind = 'foo'
+      subject.valid?
+      expect(subject.errors[:kind].size).to eq(1)
+    end
+
+    it "should have a kind" do
+      subject.kind = nil
+      subject.valid?
+      expect(subject.errors[:kind].size).to eq(2)
+    end
+  end
+
+  describe "#data" do
+    it "should have a valid serializable data field" do
+      payload = { channel: 'foo', bot_username: 'bar', private_uri: 'baz' }
+      subject.data = payload
+      subject.save
+      subject.reload
+
+      expect(subject.data['channel']).to eq('foo')
+      expect(subject.data['bot_username']).to eq('bar')
+      expect(subject.data['private_uri']).to eq('baz')
+    end
+  end
+end

--- a/spec/models/story_observer_spec.rb
+++ b/spec/models/story_observer_spec.rb
@@ -5,7 +5,7 @@ describe StoryObserver do
   subject { StoryObserver.instance }
 
   let(:story) do
-    mock_model(Story, state_changed?: false, accepted_at_changed?: false)
+    mock_model(Story, title: "Test Story", acting_user: FactoryGirl.build(:user), state_changed?: false, accepted_at_changed?: false)
   end
 
   # FIXME - Better coverage needed
@@ -13,7 +13,7 @@ describe StoryObserver do
 
     context "when story state changed" do
 
-      let(:project) { mock_model(Project) }
+      let(:project) { mock_model(Project, id: 1, name: "Test Project") }
 
       before do
         allow(project).to receive_messages(:suppress_notifications => false)
@@ -56,7 +56,7 @@ describe StoryObserver do
           expect(Notifications).to receive(:started).with(story, acting_user) {
             notifier
           }
-          expect(IntegrationWorker).to receive(:perform_async).with(story.project_id, "hello")
+          expect(IntegrationWorker).to receive(:perform_async).with(1, "[Test Project] The story 'Test Story' has been started.")
           subject.after_save(story)
         end
         it "sends 'delivered' email notification" do
@@ -64,7 +64,7 @@ describe StoryObserver do
           expect(Notifications).to receive(:delivered).with(story, acting_user) {
             notifier
           }
-          expect(IntegrationWorker).to receive(:perform_async).with(story.project_id, "hello")
+          expect(IntegrationWorker).to receive(:perform_async).with(1, "[Test Project] The story 'Test Story' has been delivered for acceptance.")
           subject.after_save(story)
         end
         it "sends 'accepted' email notification" do
@@ -72,7 +72,7 @@ describe StoryObserver do
           expect(Notifications).to receive(:accepted).with(story, acting_user) {
             notifier
           }
-          expect(IntegrationWorker).to receive(:perform_async).with(story.project_id, "hello")
+          expect(IntegrationWorker).to receive(:perform_async).with(1, "[Test Project]  ACCEPTED your story 'Test Story'.")
           subject.after_save(story)
         end
         it "sends 'rejected' email notification" do
@@ -80,7 +80,7 @@ describe StoryObserver do
           expect(Notifications).to receive(:rejected).with(story, acting_user) {
             notifier
           }
-          expect(IntegrationWorker).to receive(:perform_async).with(story.project_id, "hello")
+          expect(IntegrationWorker).to receive(:perform_async).with(1, "[Test Project]  REJECTED your story 'Test Story'.")
           subject.after_save(story)
         end
       end

--- a/spec/models/story_observer_spec.rb
+++ b/spec/models/story_observer_spec.rb
@@ -50,6 +50,13 @@ describe StoryObserver do
           expect(notifier).to receive(:deliver)
         end
 
+        it "sends 'started' email notification" do
+          allow(story).to receive_messages(:state => 'started')
+          expect(Notifications).to receive(:started).with(story, acting_user) {
+            notifier
+          }
+          subject.after_save(story)
+        end
         it "sends 'delivered' email notification" do
           allow(story).to receive_messages(:state => 'delivered')
           expect(Notifications).to receive(:delivered).with(story, acting_user) {

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 describe Story do
 
   subject { build :story, :with_project }
+  before {
+    subject.acting_user = FactoryGirl.build(:user)
+  }
 
   describe 'scopes' do
     let!(:story) { create(:story, :with_project, labels: 'feature,test') }

--- a/spec/workers/integration_worker_spec.rb
+++ b/spec/workers/integration_worker_spec.rb
@@ -11,4 +11,14 @@ describe IntegrationWorker do
       "Hello World")
     IntegrationWorker.new.perform(integration.project_id, "Hello World")
   end
+
+  it "should read URI from ENV" do
+    integration.data['private_uri'] = 'INTEGRATION_URI_MATTERMOST'
+    expect(Mattermost).to receive(:send).with(
+      'http://foo.com',
+      integration.data['channel'],
+      integration.data['bot_username'],
+      "Hello World")
+    IntegrationWorker.new.perform(integration.project_id, "Hello World")
+  end
 end

--- a/spec/workers/integration_worker_spec.rb
+++ b/spec/workers/integration_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe IntegrationWorker do
+  let(:integration) { FactoryGirl.create(:integration) }
+
+  it "should send a message to mattermost" do
+    expect(Mattermost).to receive(:send).with(
+      integration.data['private_uri'],
+      integration.data['channel'],
+      integration.data['bot_username'],
+      "Hello World")
+    IntegrationWorker.new.perform(integration.project_id, "Hello World")
+  end
+end


### PR DESCRIPTION
First version of a simple integrations administration section in the Project details. It only has Mattermost right now, but it should simple enough to add more integrations later.

The code was inserted in the existing StoryObserver that already is used to send e-mail notifications. This could be refactored into a separated service later as well.

![message pushed to mattermost channel](https://cloud.githubusercontent.com/assets/2840/17778224/b294e984-6539-11e6-8bdd-011971da18a4.png)

![administration of integrations on project edit form](https://cloud.githubusercontent.com/assets/2840/17778225/b2b1b6ea-6539-11e6-9161-7ca3a0290eed.png)

cc @daniloisr @adbatista 