### PR TITLE
Add migration to prevent empty usernames

### DIFF
--- a/db/migrate/20160730022819_remove_default_username_from_users.rb
+++ b/db/migrate/20160730022819_remove_default_username_from_users.rb
@@ -1,0 +1,26 @@
+class RemoveDefaultUsernameFromUsers < ActiveRecord::Migration
+  # User with nil username will receive their emails as username:
+  # eg:
+  #   user.test@gmail.com => user.test
+  #   user.test@live.com  => user.test.live
+  def up
+    User.where(username: '').each do |user|
+      username, domain = user.email.split('@')
+
+      user.username =
+        if User.where(username: username).empty?
+          username
+        else
+          [username, domain.split('.').first].join('.')
+        end
+
+      user.save!
+    end
+
+    change_column_default :users, :username, nil
+  end
+
+  def down
+    change_column_default :users, :username, ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 20160818013050) do
     t.string   "locale"
     t.boolean  "is_admin",               default: false
     t.integer  "memberships_count",      default: 0
-    t.string   "username",               default: "",    null: false
+    t.string   "username",                               null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
User have a validation to prevent empty usernames, but the default was `''`. So our database had a lot of invalid users.

* This was preventing us to manage users, like adding them to a project.
* The code that fill usernames on production was a suggestion from @akitaonrails and we already ran it on our servers.

/cc @akitaonrails, @tiarly 