### PR TITLE
Time zone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   before_filter :authenticate_user!, :set_locale
+  around_filter :user_time_zone, if: :current_user
 
   rescue_from ActiveRecord::RecordNotFound, :with => :render_404
 
@@ -30,5 +31,9 @@ class ApplicationController < ActionController::Base
     else
       I18n.locale = :en
     end
+  end
+
+  def user_time_zone(&block)
+    Time.use_zone(current_user.time_zone, &block)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -132,7 +132,7 @@ class Project < ActiveRecord::Base
     if !value || value == "0"
       self.archived_at = nil
     else
-      self.archived_at = Time.zone.now
+      self.archived_at = Time.current
     end
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -260,7 +260,7 @@ class Story < ActiveRecord::Base
       if state_changed?
         if state == 'accepted' && accepted_at == nil
           # Set accepted at to today when accepted
-          self.accepted_at = Date.today
+          self.accepted_at = Date.current
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
 
   def set_random_password_if_blank
     if new_record? && self.password.blank? && self.password_confirmation.blank?
-      self.password = self.password_confirmation = Digest::SHA1.hexdigest("--#{Time.now.to_s}--#{email}--")[0,8]
+      self.password = self.password_confirmation = Digest::SHA1.hexdigest("--#{Time.current.to_s}--#{email}--")[0,8]
     end
   end
 
@@ -45,7 +45,7 @@ class User < ActiveRecord::Base
   def set_reset_password_token
     raw, enc = Devise.token_generator.generate(self.class, :reset_password_token)
     self.reset_password_token   = enc
-    self.reset_password_sent_at = Time.now.utc
+    self.reset_password_sent_at = Time.current.utc
     self.save(:validate => false)
     raw
   end

--- a/app/operations/story_operations/legacy_fixes.rb
+++ b/app/operations/story_operations/legacy_fixes.rb
@@ -7,7 +7,7 @@ module StoryOperations
       # 'unscheduled'
       # FIXME Make model method on Story
       if model.project && !model.project.start_date && !['unstarted', 'unscheduled'].include?(model.state)
-        model.project.start_date = Date.today
+        model.project.start_date = Date.current
       end
     end
 

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -36,6 +36,11 @@
       </div>
 
       <div class="field-wrapper">
+        <%= f.label :time_zone, class: 'col-sm-2 control-label' %>
+        <div class="col-sm-10"><%= f.time_zone_select :time_zone, nil, default: Time.zone %></div>
+      </div>
+
+      <div class="field-wrapper">
         <%= f.label :password, class: 'col-sm-2 control-label' %>
         <div class="col-sm-10">
           <%= f.password_field :password %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module Fulcrum
 
     config.i18n.available_locales = ['de', 'el', 'en', 'es', 'nl', 'ja', 'pt-BR']
 
+    config.time_zone = 'Brasilia' # default timezone
+
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join('lib/integrations')
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -129,6 +129,7 @@ de:
         locale:               'Locale'
         is_admin:             'Ist Administrator?'
         current_password:     'Aktuelles Passwort'
+        time_zone:            'Zeitzone'
 
     errors:
       models:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -344,6 +344,7 @@ el:
         locale:               'Τοπικές ρυθμίσεις'
         is_admin:             'Είναι διαχειριστής;'
         current_password:     'τρέχων κωδικός πρόσβασης'
+        time_zone:            'ζώνη ώρας'
 
     errors:
       models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -135,6 +135,7 @@ es:
         locale:               'Configuración regional'
         is_admin:             '¿Es administrador?'
         current_password:     'contraseña actual'
+        time_zone:            'zona horaria'
 
     errors:
       models:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -129,6 +129,7 @@ ja:
         locale:               'ロケール'
         is_admin:             '管理者ですか'
         current_password:     '現在のパスワード'
+        time_zone:            '時間帯'
 
   projects:
     new project:        "新規プロジェクト"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -125,6 +125,7 @@ nl:
         password_confirmation: 'Wachtwoord bevestigen'
         locale:               'Locale'
         is_admin:             'Is Administrator?'
+        time_zone:            'tijdzone'
 
     errors:
       models:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -144,6 +144,7 @@ pt-BR:
         locale:               'Região'
         is_admin:             'É Administrador?'
         current_password:     'Senha atual'
+        time_zone:            'fuso horário'
 
     errors:
       models:

--- a/db/migrate/20160831134320_add_time_zone_to_users.rb
+++ b/db/migrate/20160831134320_add_time_zone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :time_zone, :string, null: false, default: 'Brasilia'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160825181243) do
+ActiveRecord::Schema.define(version: 20160831134320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,8 +133,8 @@ ActiveRecord::Schema.define(version: 20160825181243) do
   add_index "tasks", ["story_id"], name: "index_tasks_on_story_id", using: :btree
 
   create_table "users", force: true do |t|
-    t.string   "email",                              default: "",    null: false
-    t.string   "encrypted_password",     limit: 128, default: "",    null: false
+    t.string   "email",                              default: "",         null: false
+    t.string   "encrypted_password",     limit: 128, default: "",         null: false
     t.string   "reset_password_token"
     t.string   "remember_token"
     t.datetime "remember_created_at"
@@ -158,7 +158,8 @@ ActiveRecord::Schema.define(version: 20160825181243) do
     t.string   "locale"
     t.boolean  "is_admin",                           default: false
     t.integer  "memberships_count",                  default: 0
-    t.string   "username",                                           null: false
+    t.string   "username",                                                null: false
+    t.string   "time_zone",                          default: "Brasilia", null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -187,7 +187,7 @@ describe Project do
     end
 
     it 'resets the archived_at datetime' do
-      subject.update_attributes(archived_at: Time.zone.now)
+      subject.update_attributes(archived_at: Time.current)
       subject.update_attributes(archived: "0")
       expect(subject.archived_at).to be_nil
     end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -232,7 +232,7 @@ describe Story do
       # FIXME This is non-deterministic
       it "gets set when state changes to 'accepted'" do
         subject.update_attribute :state, 'accepted'
-        expect(subject.accepted_at).to eq(Date.today)
+        expect(subject.accepted_at).to eq(Date.current)
       end
 
     end

--- a/spec/operations/project_operations_spec.rb
+++ b/spec/operations/project_operations_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ProjectOperations do
   let(:user)           { create(:user) }
-  let(:project_params) { { name: 'Foo bar', start_date: Date.today } }
+  let(:project_params) { { name: 'Foo bar', start_date: Date.current } }
   let(:project) { user.projects.build(project_params) }
 
   describe 'Create' do

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -80,7 +80,7 @@ describe StoryOperations do
       story.save!
     end
 
-    subject { ->{StoryOperations::Update.(story, { state: 'accepted', accepted_at: Date.today }, user) } }
+    subject { ->{StoryOperations::Update.(story, { state: 'accepted', accepted_at: Date.current }, user) } }
 
     context "::LegacyFixes" do
 
@@ -90,7 +90,7 @@ describe StoryOperations do
       end
 
       it "sets the project start date if it's newer than the accepted story" do
-        story.project.update_attribute(:start_date, Date.today + 2.days)
+        story.project.update_attribute(:start_date, Date.current + 2.days)
         expect(subject.call.project.start_date).to eq(story.accepted_at)
       end
 

--- a/spec/presenters/activity_presenter_spec.rb
+++ b/spec/presenters/activity_presenter_spec.rb
@@ -69,7 +69,7 @@ describe ActivityPresenter do
         project.start_date = nil
         project.save
 
-        project.start_date = Date.parse('2016-08-30')
+        project.start_date = Date.parse('2016-08-30').in_time_zone
         activity.subject = project
         activity.save
         expect(subject.description).to eq("#{user_name} updated Project '<a href=\"/projects/test-project\">Test Project</a>' changing start_date to '2016-08-30'")
@@ -102,11 +102,11 @@ describe ActivityPresenter do
       end
 
       it 'describes changes in project' do
-        project.start_date = Date.parse('2016-07-01')
+        project.start_date = Date.parse('2016-07-01').in_time_zone
         project.save
 
         project.name = 'New Project'
-        project.start_date = Date.parse('2016-08-30')
+        project.start_date = Date.parse('2016-08-30').in_time_zone
         activity.subject = project
         activity.save
         expect(subject.description).to eq("#{user_name} updated Project '<a href=\"/projects/test-project\">New Project</a>' changing name from 'Test Project' to 'New Project', start_date from '2016-07-01' to '2016-08-30'")

--- a/spec/services/iteration_service_spec.rb
+++ b/spec/services/iteration_service_spec.rb
@@ -4,21 +4,21 @@ describe IterationService do
   let(:project) { FactoryGirl.create :project,
                   iteration_start_day: 2,
                   iteration_length: 1,
-                  start_date: Time.parse('2016/05/13') }
+                  start_date: Time.zone.parse('2016/05/13') }
   let(:service) { IterationService.new(project) }
 
   it 'should return the start of the current iteration' do
-    expect(service.iteration_start_date).to eq(Time.parse('2016/05/10'))
+    expect(service.iteration_start_date).to eq(Time.zone.parse('2016/05/10'))
   end
 
   it 'should return the iteration number for a date' do
-    expect(service.iteration_number_for_date(Time.parse('2016/08/22'))).to eq(15)
-    expect(service.iteration_number_for_date(Time.parse('2016/08/23'))).to eq(16)
+    expect(service.iteration_number_for_date(Time.zone.parse('2016/08/22'))).to eq(15)
+    expect(service.iteration_number_for_date(Time.zone.parse('2016/08/23'))).to eq(16)
   end
 
   it 'should return the starting date of an iteration' do
-    expect(service.date_for_iteration_number(15)).to eq(Time.parse('2016/08/16'))
-    expect(service.date_for_iteration_number(16)).to eq(Time.parse('2016/08/23'))
+    expect(service.date_for_iteration_number(15)).to eq(Time.zone.parse('2016/08/16'))
+    expect(service.date_for_iteration_number(16)).to eq(Time.zone.parse('2016/08/23'))
   end
 
   context "same specs from project_spec.js/start date describe block" do
@@ -29,25 +29,25 @@ describe IterationService do
 
     it 'should return the start date"' do
       # Date is a Monday, and day 1 is Monday
-      project.start_date = Time.parse "2011/09/12"
-      expect(service.iteration_start_date).to eq(Time.parse("2011/09/12"))
+      project.start_date = Time.zone.parse "2011/09/12"
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/09/12"))
 
       # If the project start date has been explicitly set to a Thursday, but
       # the iteration_start_day is Monday, the start date should be the Monday
       # that immeadiatly preceeds the Thursday.
-      project.start_date = Time.parse "2011/07/28"
-      expect(service.iteration_start_date).to eq(Time.parse("2011/07/25"))
+      project.start_date = Time.zone.parse "2011/07/28"
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/07/25"))
 
       # The same, but this time the iteration start day is 'after' the start
       # date day, in ordinal terms, e.g. iteration start date is a Saturday,
       # project start date is a Thursday.  The Saturday prior to the Thursday
       # should be returned.
       project.iteration_start_day = 6
-      expect(service.iteration_start_date).to eq(Time.parse("2011/07/23"))
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/07/23"))
 
       # If the project start date is not set, it should be considered as the
       # first iteration start day prior to today.
-      expected_date = Time.parse('2011/07/23')
+      expected_date = Time.zone.parse('2011/07/23')
       expect(service.iteration_start_date).to eq(expected_date)
     end
   end
@@ -60,12 +60,12 @@ describe IterationService do
 
     it 'should get the right iteration number for a given date' do
       # This is a Monday
-      service.start_date = Time.parse("2011/07/25")
+      service.start_date = Time.zone.parse("2011/07/25")
 
-      compare_date = Time.parse("2011/07/25")
+      compare_date = Time.zone.parse("2011/07/25")
       expect(service.iteration_number_for_date(compare_date)).to eq(1)
 
-      compare_date = Time.parse("2011/08/01")
+      compare_date = Time.zone.parse("2011/08/01")
       expect(service.iteration_number_for_date(compare_date)).to eq(2)
 
       # With a 2 week iteration length, the date above will still be in
@@ -76,25 +76,25 @@ describe IterationService do
 
     it 'should get the right iteration number for a given date' do
       # This is a Monday
-      service.start_date = Time.parse "2011/07/25"
+      service.start_date = Time.zone.parse "2011/07/25"
 
-      expect(service.date_for_iteration_number(1)).to eq(Time.parse("2011/07/25"))
-      expect(service.date_for_iteration_number(5)).to eq(Time.parse("2011/08/22"))
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/25"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/08/22"))
 
       service.iteration_length = 4
-      expect(service.date_for_iteration_number(1)).to eq(Time.parse("2011/07/25"))
-      expect(service.date_for_iteration_number(5)).to eq(Time.parse("2011/11/14"))
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/25"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/14"))
 
       # Sunday
       service.iteration_start_day = 0
-      expect(service.date_for_iteration_number(1)).to eq(Time.parse("2011/07/24"))
-      expect(service.date_for_iteration_number(5)).to eq(Time.parse("2011/11/13"))
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/24"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/13"))
 
       # Tuesday - This should evaluate to the Tuesday before the explicitly
       # set start date (Monday)
       service.iteration_start_day = 2
-      expect(service.date_for_iteration_number(1)).to eq(Time.parse("2011/07/19"))
-      expect(service.date_for_iteration_number(5)).to eq(Time.parse("2011/11/08"))
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/19"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/08"))
     end
   end
 end


### PR DESCRIPTION
Up until now, the system was entirely in UTC in the back-end and the front-end uses the browser client's time zone, so the iteration calculations will be different in reports, for example. 

Also, project start date, story accepted date, all could hit time zone related bugs.

This adds a user configurable time zone