### PR TITLE
Fix click on left estimate and story spacing

### DIFF
--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -68,7 +68,7 @@ Fulcrum.StoryView = Fulcrum.FormView.extend({
     "click .submit": "saveEdit",
     "click .cancel": "cancelEdit",
     "click .transition": "transition",
-    "click .estimate": "estimate",
+    "click .state-actions .estimate": "estimate",
     "change select.story_type": "disableEstimate",
     "click .destroy": "clear",
     "click .description": "editDescription",

--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -226,6 +226,10 @@ div.story {
   background-color: #eee;
   border-bottom: 1px solid #ddd;
   border-top: 1px solid #fff;
+
+  &:not(.editing):not(.unestimated) {
+    height: 37px;
+  }
 }
 div.story:hover {
   background-color: #ddd;
@@ -261,7 +265,7 @@ div.story-icons {
   margin-top: -10px;
 
   .estimate {
-    top: 2px;
+    top: 9px;
     left: 1px;
   }
 }
@@ -319,7 +323,7 @@ div.story-title abbr.initials {
 }
 
 .estimates {
-  margin-top: 4px;
+  margin-top: 12px;
   margin-right: 6px;
 
   .estimate {


### PR DESCRIPTION
Currently when you click on the estimate icon on the left side of the story:

![screen shot 2016-09-01 at 5 38 35 pm](https://cloud.githubusercontent.com/assets/4325587/18183534/329c57fc-706b-11e6-91e3-a94da1a20d5a.png)

You get an exception:

![screen shot 2016-09-01 at 5 38 47 pm](https://cloud.githubusercontent.com/assets/4325587/18183535/329ca324-706b-11e6-9261-2dbf9a5d7e7a.png)

It happens because the's a listener for clicking there that should only be allowed for unestimated  stories. This PR fixes that listener and also fix some minor spacing issues inside the closed story view.