### PR TITLE
Fixing the accepted_at datetime -> date in the javascript

### DIFF
--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -228,9 +228,17 @@ Fulcrum.Story = Backbone.Model.extend({
 
   iterationNumber: function() {
     if (this.get('state') === "accepted") {
-      var date_part = this.get("accepted_at").split(" ")[0];
-      return this.collection.project.getIterationNumberForDate(new Date(date_part));
+      return this.collection.project.getIterationNumberForDate(this.acceptedAtBeginningOfDay());
     }
+  },
+
+  acceptedAtBeginningOfDay: function() {
+    var accepted_at = new Date(this.get("accepted_at"));
+    accepted_at.setHours(0);
+    accepted_at.setMinutes(0);
+    accepted_at.setSeconds(0);
+    accepted_at.setMilliseconds(0);
+    return accepted_at;
   },
 
   // If the story state is 'accepted', and the 'accepted_at' attribute is not

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -228,7 +228,8 @@ Fulcrum.Story = Backbone.Model.extend({
 
   iterationNumber: function() {
     if (this.get('state') === "accepted") {
-      return this.collection.project.getIterationNumberForDate(new Date(this.get("accepted_at")));
+      var date_part = this.get("accepted_at").split(" ")[0];
+      return this.collection.project.getIterationNumberForDate(new Date(date_part));
     }
   },
 


### PR DESCRIPTION
In the server side, the accepted_at now is a date time, but the javascript part expected accepted_at to be just a date (equivalent to ‘beginning of day’) so stripping away the time part to make it work like before.

It was causing some projects to not open because the missingIteration function was trying to create a sprint with a startIteration number larger than the lastIteration number. And it was probably also causing iterations to finish earlier.

Stripping the time part should make the JS part work as before.

(WIP) check out the rest of the JS code to see other places using new Date(story.get("accepted_at")) and stripping the time part.

@rodrigovirgilio @adbatista 