### PR TITLE
Check if user belongs to team before adding him

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
       flash[:alert] = I18n.t('is already a member of this project', scope: 'users', email: @user.email)
     else
       policy_scope(User) << @user
-      @user.teams << current_team
+      @user.teams << current_team unless @user.teams.include?(current_team)
       if @user.was_created
         flash[:notice] = I18n.t('was sent an invite to join this project', scope: 'users', email: @user.email)
       else

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -108,6 +108,17 @@ describe UsersController do
           end
         end
 
+        context 'when user exists in the team' do
+          specify do
+            new_user = create(:user, user_params.merge(teams: user.teams))
+
+            post :create, project_id: project.id, user: user_params
+
+            expect(response).to redirect_to(project_users_url(project))
+            expect(project.users).to include(new_user)
+          end
+        end
+
         context "when user is already a project member" do
 
           before do


### PR DESCRIPTION
Fix the following exception:

```
PG::UniqueViolation - ERROR:  duplicate key value violates unique constraint "index_enrollments_on_team_id_and_user_id"
```