### PR TITLE
Prevent empty string being used as location

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = session[:locale] || current_user.try(:locale).try(:to_sym) || :en
+    options = [session[:locale], current_user.try(:locale).try(:to_sym), :en]
+    I18n.locale = (options & I18n.available_locales).first
   end
 
   def user_time_zone(&block)


### PR DESCRIPTION
For some reason my `session[:locale]` is an empty string, what is preventing me from accessing the app.

```ruby
irb(main):001:0> '' || nil || :en
=> ""
```

![screen shot 2016-09-28 at 5 04 22 pm](https://cloud.githubusercontent.com/assets/157134/18930257/b92def28-859d-11e6-8c62-9cb3dafb638e.png)
