### PR TITLE
Fix Notifications params with Sidekiq

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -3,36 +3,36 @@ class Notifications < ActionMailer::Base
 
   delegate :name, to: :project, prefix: true
 
-  def started(story, owned_by)
-    @story = story
-    @owned_by = owned_by
+  def started(story_id, user_id)
+    @story = Story.find(story_id)
+    @user = User.find(user_id)
 
-    mail to: story.requested_by.email, from: owned_by.email,
-      subject: "[#{story.project.name}] Your story '#{story.title}' has been started."
+    mail to: @story.requested_by.email, from: @user.email,
+      subject: "[#{@story.project.name}] Your story '#{@story.title}' has been started."
   end
 
-  def delivered(story, delivered_by)
-    @story = story
-    @delivered_by = delivered_by
+  def delivered(story_id, user_id)
+    @story = Story.find(story_id)
+    @user = User.find(user_id)
 
-    mail to: story.requested_by.email, from: delivered_by.email,
-      subject: "[#{story.project.name}] Your story '#{story.title}' has been delivered for acceptance."
+    mail to: @story.requested_by.email, from: @user.email,
+      subject: "[#{@story.project.name}] Your story '#{@story.title}' has been delivered for acceptance."
   end
 
-  def accepted(story, accepted_by)
-    @story = story
-    @accepted_by = accepted_by
+  def accepted(story_id, user_id)
+    @story = Story.find(story_id)
+    @user = User.find(user_id)
 
-    mail to: story.owned_by.email, from: accepted_by.email,
-      subject: "[#{story.project.name}] #{accepted_by.name} ACCEPTED your story '#{story.title}'."
+    mail to: @story.owned_by.email, from: @user.email,
+      subject: "[#{@story.project.name}] #{@user.name} ACCEPTED your story '#{@story.title}'."
   end
 
-  def rejected(story, rejected_by)
-    @story = story
-    @accepted_by = rejected_by
+  def rejected(story_id, user_id)
+    @story = Story.find(story_id)
+    @user = User.find(user_id)
 
-    mail to: story.owned_by.email, from: rejected_by.email,
-      subject: "[#{story.project.name}] #{rejected_by.name} REJECTED your story '#{story.title}'."
+    mail to: @story.owned_by.email, from: @user.email,
+      subject: "[#{@story.project.name}] #{@user.name} REJECTED your story '#{@story.title}'."
   end
 
   # Send notification to of a new note to the listed users
@@ -44,10 +44,10 @@ class Notifications < ActionMailer::Base
       subject: "[#{@story.project.name}] New comment on '#{@story.title}'"
   end
 
-  def story_mention(story, users_to_notify)
-    @story = story
+  def story_mention(story_id, users_to_notify)
+    @story = Story.find(story_id)
 
-    mail to: users_to_notify.map(&:email), from: @story.requested_by.email,
+    mail to: users_to_notify, from: @story.requested_by.email,
       subject: "[#{@story.project.name}] New mention on '#{@story.title}'"
   end
 end

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -2,9 +2,12 @@ class Notifications < ActionMailer::Base
   def story_changed(story, actor)
     @story = story
     @actor = actor
+    state = story.state.to_sym
 
-    mail_params = MailParams.new(story, actor).send(story.status.to_sym)
-    mail mail_params.merge(template_name: story.status)
+    mail_params = MailParams.new(story, actor)
+    return unless mail_params.methods.include?(state)
+
+    mail mail_params.send(state).merge(template_name: state)
   end
 
   # Send notification to of a new note to the listed users

--- a/app/operations/story_operations/member_notification.rb
+++ b/app/operations/story_operations/member_notification.rb
@@ -9,8 +9,7 @@ module StoryOperations
     def notify_users
       return unless can_notify_mentioned_users?
 
-      notifier = Notifications.story_mention(model.id, users_to_notify.pluck(:email))
-      notifier.deliver if notifier
+      Notifications.story_mention(model, users_to_notify.pluck(:email)).deliver_later
     end
 
     def users_from_story

--- a/app/operations/story_operations/member_notification.rb
+++ b/app/operations/story_operations/member_notification.rb
@@ -9,7 +9,7 @@ module StoryOperations
     def notify_users
       return unless can_notify_mentioned_users?
 
-      notifier = Notifications.story_mention(model, users_to_notify)
+      notifier = Notifications.story_mention(model.id, users_to_notify.pluck(:email))
       notifier.deliver if notifier
     end
 

--- a/app/operations/story_operations/state_change_notification.rb
+++ b/app/operations/story_operations/state_change_notification.rb
@@ -3,7 +3,7 @@ module StoryOperations
     def notify_state_changed
       return unless can_notify_state_changed?
 
-      notifier = Notifications.public_send(model.state.to_sym, model, model.acting_user)
+      notifier = Notifications.public_send(model.state.to_sym, model.id, model.acting_user.id)
       notifier.deliver if notifier
       IntegrationWorker.perform_async(model.project.id, integration_message)
     end

--- a/app/operations/story_operations/state_change_notification.rb
+++ b/app/operations/story_operations/state_change_notification.rb
@@ -3,8 +3,7 @@ module StoryOperations
     def notify_state_changed
       return unless can_notify_state_changed?
 
-      notifier = Notifications.public_send(model.state.to_sym, model.id, model.acting_user.id)
-      notifier.deliver if notifier
+      Notifications.story_changed(model, model.acting_user).deliver_later
       IntegrationWorker.perform_async(model.project.id, integration_message)
     end
 

--- a/app/views/notifications/accepted.text.erb
+++ b/app/views/notifications/accepted.text.erb
@@ -1,3 +1,3 @@
-<%= @accepted_by.name %> has accepted the story '<%= @story.title %>'.
+<%= @user.name %> has accepted the story '<%= @story.title %>'.
 
 <%= project_url @story.project %>#story-<%= @story.id %>

--- a/app/views/notifications/accepted.text.erb
+++ b/app/views/notifications/accepted.text.erb
@@ -1,3 +1,3 @@
-<%= @user.name %> has accepted the story '<%= @story.title %>'.
+<%= @actor.name %> has accepted the story '<%= @story.title %>'.
 
 <%= project_url @story.project %>#story-<%= @story.id %>

--- a/app/views/notifications/delivered.text.erb
+++ b/app/views/notifications/delivered.text.erb
@@ -1,4 +1,4 @@
-<%= @user.name %> has delivered your story '<%= @story.title %>'.
+<%= @actor.name %> has delivered your story '<%= @story.title %>'.
 
 You can now review the story, and either accept or reject it.
 

--- a/app/views/notifications/delivered.text.erb
+++ b/app/views/notifications/delivered.text.erb
@@ -1,4 +1,4 @@
-<%= @delivered_by.name %> has delivered your story '<%= @story.title %>'.
+<%= @user.name %> has delivered your story '<%= @story.title %>'.
 
 You can now review the story, and either accept or reject it.
 

--- a/app/views/notifications/rejected.text.erb
+++ b/app/views/notifications/rejected.text.erb
@@ -1,3 +1,3 @@
-<%= @accepted_by.name %> has rejected the story '<%= @story.title %>'.
+<%= @user.name %> has rejected the story '<%= @story.title %>'.
 
 <%= project_url @story.project %>#story-<%= @story.id %>

--- a/app/views/notifications/rejected.text.erb
+++ b/app/views/notifications/rejected.text.erb
@@ -1,3 +1,3 @@
-<%= @user.name %> has rejected the story '<%= @story.title %>'.
+<%= @actor.name %> has rejected the story '<%= @story.title %>'.
 
 <%= project_url @story.project %>#story-<%= @story.id %>

--- a/app/views/notifications/started.text.erb
+++ b/app/views/notifications/started.text.erb
@@ -1,10 +1,10 @@
-<%= @owned_by.name %> has started your story '<%= @story.title %>'.
+<%= @user.name %> has started your story '<%= @story.title %>'.
 
 <% if (@story.estimate.nil? || @story.estimate == 0) %>
   <% if @story.story_type != 'feature' %>
 This is either a bug or a chore There is no estimation. Expect the sprint velocity to decrease.
   <% else %>
-This story is NOT estimated. Ask <%= @owned_by.name %> to add proper estimation before implementation!
+This story is NOT estimated. Ask <%= @user.name %> to add proper estimation before implementation!
   <% end %>
 <% else %>
 The estimation of this story is <%= @story.estimate %> points.

--- a/app/views/notifications/started.text.erb
+++ b/app/views/notifications/started.text.erb
@@ -1,10 +1,10 @@
-<%= @user.name %> has started your story '<%= @story.title %>'.
+<%= @actor.name %> has started your story '<%= @story.title %>'.
 
 <% if (@story.estimate.nil? || @story.estimate == 0) %>
   <% if @story.story_type != 'feature' %>
 This is either a bug or a chore There is no estimation. Expect the sprint velocity to decrease.
   <% else %>
-This story is NOT estimated. Ask <%= @user.name %> to add proper estimation before implementation!
+This story is NOT estimated. Ask <%= @actor.name %> to add proper estimation before implementation!
   <% end %>
 <% else %>
 The estimation of this story is <%= @story.estimate %> points.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,15 +15,8 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  #config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: config.fulcrum.app_host }
-
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.smtp_settings = {
-    address: ENV['MAIL_SMTP_HOST'],
-    port: ENV['MAIL_SMTP_PORT']
-  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -12,8 +12,15 @@ describe Notifications do
     )
   end
 
+  describe '#story_changed with invalid state' do
+    before { allow(story).to receive_messages(state: :invalid_state) }
+    subject { Notifications.story_changed(story, double).__getobj__ }
+
+    it { is_expected.to be_a ActionMailer::Base::NullMail }
+  end
+
   describe "#story_changed to started" do
-    before { allow(story).to receive_messages(status: :started) }
+    before { allow(story).to receive_messages(state: :started) }
     subject { Notifications.story_changed(story, owned_by) }
 
     its(:subject) { should match "[Test Project] Your story 'Test story' has been started."}
@@ -41,7 +48,7 @@ describe Notifications do
 
   describe "#story_changed to delivered" do
     let(:delivered_by) { mock_model(User, name: 'Deliverer', email: 'delivered_by@email.com') }
-    before { allow(story).to receive_messages(status: :delivered) }
+    before { allow(story).to receive_messages(state: :delivered) }
     subject  { Notifications.story_changed(story, delivered_by) }
 
     its(:subject) { should match "[Test Project] Your story 'Test story' has been delivered for acceptance." }
@@ -55,7 +62,7 @@ describe Notifications do
   describe "#story_changed to accepted" do
     let(:accepted_by) { mock_model(User, name: 'Accepter', email: 'accerpter@email.com') }
 
-    before { allow(story).to receive_messages(status: :accepted) }
+    before { allow(story).to receive_messages(state: :accepted) }
     subject { Notifications.story_changed(story, accepted_by) }
 
     its(:subject) { should match "[Test Project] Accepter ACCEPTED your story 'Test story'." }
@@ -68,7 +75,7 @@ describe Notifications do
   describe "#story_changed to rejected" do
     let(:rejected_by) { mock_model(User, name: 'Rejecter', email: 'rejecter@email.com') }
 
-    before { allow(story).to receive_messages(status: :rejected) }
+    before { allow(story).to receive_messages(state: :rejected) }
     subject { Notifications.story_changed(story, rejected_by) }
 
     its(:subject) { should match "[Test Project] Rejecter REJECTED your story 'Test story'." }

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -36,7 +36,7 @@ describe StoryOperations do
 
       it 'also sends notification for the found username' do
         expect(Notifications).to receive(:story_mention).
-          with(story, [username_user]).and_return(mailer)
+          with(story.id, [username_user.email]).and_return(mailer)
         expect(mailer).to receive(:deliver)
 
         subject.call
@@ -116,7 +116,7 @@ describe StoryOperations do
 
       it "sends 'started' email notification" do
         allow(story).to receive_messages(:state => 'started')
-        expect(Notifications).to receive(:public_send).with(:started, story, acting_user) {
+        expect(Notifications).to receive(:public_send).with(:started, story.id, acting_user.id) {
           notifier
         }
         expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been started.")
@@ -124,7 +124,7 @@ describe StoryOperations do
       end
       it "sends 'delivered' email notification" do
         allow(story).to receive_messages(:state => 'delivered')
-        expect(Notifications).to receive(:public_send).with(:delivered, story, acting_user) {
+        expect(Notifications).to receive(:public_send).with(:delivered, story.id, acting_user.id) {
           notifier
         }
         expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been delivered for acceptance.")
@@ -132,7 +132,7 @@ describe StoryOperations do
       end
       it "sends 'accepted' email notification" do
         allow(story).to receive_messages(:state => 'accepted')
-        expect(Notifications).to receive(:public_send).with(:accepted, story, acting_user) {
+        expect(Notifications).to receive(:public_send).with(:accepted, story.id, acting_user.id) {
           notifier
         }
         expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project]  ACCEPTED your story ['Test Story'](http://foo.com/projects/123#story-#{story.id}).")
@@ -140,7 +140,7 @@ describe StoryOperations do
       end
       it "sends 'rejected' email notification" do
         allow(story).to receive_messages(:state => 'rejected')
-        expect(Notifications).to receive(:public_send).with(:rejected, story, acting_user) {
+        expect(Notifications).to receive(:public_send).with(:rejected, story.id, acting_user.id) {
           notifier
         }
         expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project]  REJECTED your story ['Test Story'](http://foo.com/projects/123#story-#{story.id}).")
@@ -150,4 +150,3 @@ describe StoryOperations do
 
   end
 end
-


### PR DESCRIPTION
After adding Sidekiq::Mailer on production all method call started to break because sidekiq pass arguments as json strings.

![screen shot 2016-09-30 at 12 02 06 pm](https://cloud.githubusercontent.com/assets/157134/18996266/07714fae-8706-11e6-8d31-5a4b011fa87d.png)
