### PR TITLE
Fix bug with `set_locale`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,8 +29,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    options = [session[:locale], current_user.try(:locale).try(:to_sym), :en]
-    I18n.locale = (options & I18n.available_locales).first
+    options = [session[:locale], current_user&.locale, 'en']
+    I18n.locale = (options & I18n.available_locales.map(&:to_s)).first
   end
 
   def user_time_zone(&block)


### PR DESCRIPTION
The `I18n.available_locales` returns an array of symbols, and it was expecting an array of strings.