### PR TITLE
Keep current team instance on edit action render when update fails

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -62,7 +62,9 @@ class TeamsController < ApplicationController
     authorize @team
 
     respond_to do |format|
-      if @team = TeamOperations::Update.(@team, allowed_params, current_user)
+      if TeamOperations::Update.(@team, allowed_params, current_user)
+        @team.reload
+
         format.html do
           flash[:notice] = t('teams.team was successfully updated')
           render action: "edit"

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -102,6 +102,14 @@ describe TeamsController, type: :controller do
             expect(response).to be_success
             expect(response).to render_template('edit')
           end
+
+          context 'when name is empty' do
+            specify do
+              put :update, id: 'xyz', team: { name: '' }
+              expect(response).to be_success
+              expect(response).to render_template('edit')
+            end
+          end
         end
       end
 


### PR DESCRIPTION
When trying to update a team name with an empty value, the `@team` var was being set as `false` (which refers to the invalid update)