### PR TITLE
Fix team switching

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -25,10 +25,6 @@ class TeamsController < ApplicationController
     end
   end
 
-  def show
-    redirect_to edit_team_path(current_team)
-  end
-
   # GET /teams/1/edit
   def edit
     @team = current_team

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
                     <% end %>
                     <li class="divider"></li>
                     <% current_user.teams.each do |team| %>
-                      <li><%= link_to team.name, team %></li>
+                      <li><%= link_to team.name, switch_teams_path(team_slug: team.slug) %></li>
                     <% end %>
                     <li class="divider"></li>
                     <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   get 't/:id' => 'teams#switch', as: :teams_switch
 
-  resources :teams do
+  resources :teams, except: :show do
     get :switch, on: :collection
     resources :api_tokens, only: [:create, :destroy]
   end


### PR DESCRIPTION
The team link on header menu was sending to `teams#show` which was broken. This PR fix the link to send it to `teams#switch` and also remove the broken action `#show`.

![screen shot 2017-01-11 at 19 37 52](https://cloud.githubusercontent.com/assets/157134/21867506/9d2bf4d8-d835-11e6-8ef4-88dbc7fb1911.png)