### PR TITLE
Fix stories import

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :set_project, except: %i[new create index archived]
+  before_action :prepare_session, only: %i[import import_upload]
 
   Project::MAX_MEMBERS_PER_CARD = 4;
 
@@ -91,7 +92,7 @@ class ProjectsController < ApplicationController
 
   # CSV import form
   def import
-    if session[:import_job]
+    if session[:import_job].present?
       if job_result = Rails.cache.read(session[:import_job][:id])
         session[:import_job] = nil
         if job_result[:errors]
@@ -110,7 +111,7 @@ class ProjectsController < ApplicationController
           end
         end
       else
-        minutes_ago = (Time.current - session[:import_job][:created_at]) / 1.minute
+        minutes_ago = (Time.current - session[:import_job][:created_at].to_datetime) / 1.minute
         if minutes_ago > 60
           session[:import_job] = nil
         end
@@ -214,4 +215,7 @@ class ProjectsController < ApplicationController
     authorize @project
   end
 
+  def prepare_session
+    session[:import_job] = (session[:import_job] || {}).with_indifferent_access
+  end
 end

--- a/app/views/projects/import.html.erb
+++ b/app/views/projects/import.html.erb
@@ -12,7 +12,7 @@
   <div class="col-sm-12 col-md-12">
     <h2><%= t('projects.uploads.title') %></h2>
 
-    <% if session[:import_job] %>
+    <% if session[:import_job].present? %>
       <%= raw t('projects.uploads.already_uploaded', time_ago: time_ago_in_words( session[:import_job][:created_at] )) %>
     <% else %>
       <%= raw t('projects.uploads.instructions') %>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -214,7 +214,7 @@ describe ProjectsController do
 
           context "still unprocessed" do
             before do
-              session[:import_job] = { id: 'foo', created_at: 10.minutes.ago }
+              session[:import_job] = { id: 'foo', created_at: 10.minutes.ago.to_s }
             end
 
             specify do
@@ -227,7 +227,7 @@ describe ProjectsController do
 
           context "unprocessed for more than 60 minutes" do
             before do
-              session[:import_job] = { id: 'foo', created_at: 2.hours.ago }
+              session[:import_job] = { id: 'foo', created_at: 2.hours.ago.to_s }
             end
 
             specify do
@@ -241,7 +241,7 @@ describe ProjectsController do
           context "finished with errors" do
             let(:error) { "Bad CSV!" }
             before do
-              session[:import_job] = { id: 'foo', created_at: 5.minutes.ago }
+              session[:import_job] = { id: 'foo', created_at: 5.minutes.ago.to_s }
               expect(Rails.cache).to receive(:read).with('foo').and_return({ invalid_stories: [], errors: error })
             end
             specify do
@@ -256,7 +256,7 @@ describe ProjectsController do
           context "finished with success" do
             let(:invalid_story) { { title: 'hello', errors: 'bad cookie'} }
             before do
-              session[:import_job] = { id: 'foo', created_at: 5.minutes.ago }
+              session[:import_job] = { id: 'foo', created_at: 5.minutes.ago.to_s }
               expect(Rails.cache).to receive(:read).with('foo').and_return({ invalid_stories: [invalid_story], errors: nil })
             end
 


### PR DESCRIPTION
I've dealt with a few problems with the stories import...
- session[:import_job][:id] 
- session[:import_job][:created_at] was a string, which could not perform an operation needed to get how many minutes ago an import job was created
- when dealing with a list of stories that were never accepted the import was not working