### PR TITLE
Improve flash notifications design

### DIFF
--- a/app/assets/stylesheets/_animations.scss
+++ b/app/assets/stylesheets/_animations.scss
@@ -6,6 +6,9 @@
     animation-fill-mode: forwards;
     animation-iteration-count: 1;
   }
+  &.slide-in-slide-out {
+    animation: slide-in-slide-out ease 4s 1;
+  }
 }
 
 @keyframes scaleIn{
@@ -17,5 +20,20 @@
   }
   100% {
     transform: scale(1);
+  }
+}
+
+@keyframes slide-in-slide-out {
+  0% {
+    transform: translateY(0);
+  }
+  5% {
+    transform: translateY(150px);
+  }
+  85% {
+    transform: translateY(150px);
+  }
+  100% {
+    transform: translateY(-300px);
   }
 }

--- a/app/assets/stylesheets/_flash-message.scss
+++ b/app/assets/stylesheets/_flash-message.scss
@@ -1,3 +1,10 @@
+.flash-message-row {
+  position: fixed;
+  top: -100px;
+  z-index: 98;
+}
+
 .flash-message {
-  margin: 25px 0;
+  margin: 25px auto;
+  width: 55%;
 }

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -8,6 +8,13 @@ body {
   padding-left: 0;
   padding-right: 0;
   height: 100%;
+  .flash-message-row {
+    width: 100%;
+    margin: auto;
+    .flash-message {
+      width: 40%;
+    }
+  }
 }
 
 .board {

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -8,9 +8,11 @@ body {
   padding-left: 0;
   padding-right: 0;
   height: 100%;
+
   .flash-message-row {
     width: 100%;
     margin: auto;
+
     .flash-message {
       width: 40%;
     }

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -2,6 +2,7 @@
   padding: 0 10px;
   margin-bottom: 0;
   border-radius: 0;
+  z-index: 99;
 
   &-logo {
     padding: 10px 15px;

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,17 +1,13 @@
 <% flash.each do |key, value| %>
-  <div class="row">
-    <div class="col-sm-12 col-md-6 col-lg-6 col-md-offset-3 col-lg-offset-3">
+  <div class="container flash-message-row animated slide-in-slide-out">
+    <div class="flash-message">
+      <%= content_tag :div, class: "alert alert-dismissible #{flash_key_to_bootstrap_class(key)}", role: 'alert' do %>
+        <button type="button" class="close" data-dismiss="alert" aria-label="<%= t('close') %>">
+          <span aria-hidden="true">&times;</span>
+        </button>
 
-      <div class="flash-message">
-        <%= content_tag :div, class: "alert alert-dismissible #{flash_key_to_bootstrap_class(key)}", role: 'alert' do %>
-          <button type="button" class="close" data-dismiss="alert" aria-label="<%= t('close') %>">
-            <span aria-hidden="true">&times;</span>
-          </button>
-
-          <%= value %>
-        <% end %>
-      </div>
-
+        <%= value %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
## Before: 
The flash messages were in a relative positioned container causing it to push down the page content.
![screenshot 2](https://cloud.githubusercontent.com/assets/5242693/22378258/c6ac84d4-e493-11e6-94c3-e0a34ae06147.jpeg)

Also, closing the notification would lead to a blank space and break a few pages layout.
![screenshot 1](https://cloud.githubusercontent.com/assets/5242693/22378262/cb502662-e493-11e6-9819-766a5417db6d.jpeg)

### After:
![on_sign_in](https://cloud.githubusercontent.com/assets/5242693/22380748/5930c0b4-e49d-11e6-9aaf-bc1a092dc9f4.gif)
![on_import](https://cloud.githubusercontent.com/assets/5242693/22380480/673ced1e-e49c-11e6-93f6-9ce80a057639.gif)
