### PR TITLE
New Project page redesign

### DIFF
--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -104,11 +104,12 @@ module.exports = Backbone.View.extend({
   },
 
   scaleToViewport: function() {
-    var storyTableTop = $('table.stories tbody').offset().top;
+    var viewSize = $('.content-wrapper').height();
+    var offsetTop = $('.project-stories').offset().top;
+    var columnHeaderSize = $('.column_header:first').outerHeight();
+    var extra = parseInt($('.project-stories').css('padding-top'));
 
-    var extra = 20;
-
-    var height = $(window).height() - (storyTableTop + extra);
+    var height = viewSize - columnHeaderSize - offsetTop - extra;
 
     $('.storycolumn').css('height', height + 'px');
 

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -24,9 +24,14 @@
     }
   }
 }
-.date-form-group {
-  .auth-form-control {
-    width: auto;
-    display: inline;
-  }
+
+.date-form-group .auth-form-control {
+  width: auto;
+  display: inline;
+}
+
+.btn-form {
+  padding: 7px 20px;
+  font-size: 14px;
+  border-radius: 0;
 }

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -26,12 +26,12 @@
 }
 
 .date-form-group .auth-form-control {
-  width: auto;
   display: inline;
+  width: auto;
 }
 
 .btn-form {
-  padding: 7px 20px;
-  font-size: 14px;
   border-radius: 0;
+  font-size: 14px;
+  padding: 7px 20px;
 }

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -23,10 +23,10 @@ body {
 }
 
 .content-wrapper {
-  top: 0;
-  right: 0;
   bottom: 0;
   left: 0;
+  right: 0;
+  top: 0;
   position: absolute;
   overflow-y: auto;
 }

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -7,7 +7,6 @@ body {
 .container-fluid {
   padding-left: 0;
   padding-right: 0;
-  height: 100%;
 
   .flash-message-row {
     width: 100%;
@@ -24,7 +23,10 @@ body {
 }
 
 .content-wrapper {
-  height: 100%;
-  width: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   position: absolute;
+  overflow-y: auto;
 }

--- a/app/assets/stylesheets/_project-settings.scss
+++ b/app/assets/stylesheets/_project-settings.scss
@@ -1,13 +1,7 @@
 /* Settings */
 .settings-page {
   background: $lightgrey-7;
-  margin-left: $sidebar-size;
   padding: 0  30px;
-  position: absolute;
-  bottom: 0;
-  top: 0;
-  right: 0;
-  left: 0;
   overflow-y: auto;
 }
 
@@ -35,16 +29,22 @@
   margin-bottom: 20px;
 }
 
-.panel-actions {
-  padding-right: 15px;
-  padding-top: 7px;
+/* Integrations */
+.panel {
+  .panel-content {
+    padding: 15px;
+  }
+}
+
+.integration > .panel-heading {
+  padding: 10px 15px;
+  vertical-align: middle;
 
   .btn-remove {
-    border-color: $darkred;
-    color: $darkred;
     float: right;
     padding: 2px 10px;
-
+    color: $darkred;
+    border-color: $darkred;
     &:hover, &:focus {
       background: $darkred;
       color: $white;
@@ -59,7 +59,6 @@
 
   .sidebar-link {
     padding-left: 1.2em;
-
     &.active {
       color: $sidebar-settings-fg-selected;
     }

--- a/app/assets/stylesheets/_project-settings.scss
+++ b/app/assets/stylesheets/_project-settings.scss
@@ -35,22 +35,16 @@
   margin-bottom: 20px;
 }
 
-/* Integrations */
-.panel {
-  .panel-content {
-    padding: 15px;
-  }
-}
-
-.integration > .panel-heading {
-  padding: 10px 15px;
-  vertical-align: middle;
+.panel-actions {
+  padding-right: 15px;
+  padding-top: 7px;
 
   .btn-remove {
+    border-color: $darkred;
+    color: $darkred;
     float: right;
     padding: 2px 10px;
-    color: $darkred;
-    border-color: $darkred;
+
     &:hover, &:focus {
       background: $darkred;
       color: $white;
@@ -65,6 +59,7 @@
 
   .sidebar-link {
     padding-left: 1.2em;
+
     &.active {
       color: $sidebar-settings-fg-selected;
     }

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -625,6 +625,7 @@ div#keycut-help {
 }
 
 .page-header {
+  margin-top: 20px;
   padding-bottom: 0;
 
   .page-header-title {

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -71,10 +71,8 @@ ul#primary-nav li {
 }
 
 .main {
-  height: 100%;
   margin: 0;
   position: relative;
-  background-color: $lightgrey-7;
 }
 
 html.stories, html.stories body, html.stories .main {
@@ -93,6 +91,7 @@ table.stories {
 table.stories td {
   vertical-align: top;
   background-color: $darkgrey-11;
+  height: 100%;
   @include border-radius(5px 5px 0 0);
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@
 @import "user-profile";
 @import "menu";
 @import "loading-spin";
+@import "form";

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -24,3 +24,9 @@
     }
   }
 }
+.date-form-group {
+  .auth-form-control {
+    width: auto;
+    display: inline;
+  }
+}

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -24,20 +24,22 @@
 
     <% @integrations.each do |integration| %>
       <div class="card panel integration">
-        <div class="panel-heading clearfix">
-          <%= integration.kind.camelcase %>
-
+        <div class="panel-actions pull-right">
           <% unless integration.new_record? %>
             <%= link_to project_integration_path(@project, integration),
                         data: { confirm: t('projects.integrations_remove_sure', kind: integration.kind) },
                         method: :delete,
-                        class: 'btn btn-sm btn-remove btn-form' do %>
+                        class: 'btn btn-sm btn-remove' do %>
               <%= material_icon.delete_forever.md_18 %> Remove
             <% end %>
           <% end %>
         </div>
 
-        <div class="panel-content">
+        <div class="panel-heading">
+          <%= integration.kind.camelcase %>
+        </div>
+
+        <div class="panel-body">
           <% if integration.new_record? %>
             <%= form_for [@project, integration] do |form| %>
               <%= form.hidden_field :kind, value: integration.kind %>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -31,7 +31,7 @@
             <%= link_to project_integration_path(@project, integration),
                         data: { confirm: t('projects.integrations_remove_sure', kind: integration.kind) },
                         method: :delete,
-                        class: 'btn btn-sm btn-remove' do %>
+                        class: 'btn btn-sm btn-remove btn-form' do %>
               <%= material_icon.delete_forever.md_18 %> Remove
             <% end %>
           <% end %>
@@ -46,7 +46,7 @@
                                   locals: { form: form } %>
 
               <div class="actions text-right">
-                <%= form.submit t('projects.integrations_new'), class: 'btn btn-primary' %>
+                <%= form.submit t('projects.integrations_new'), class: 'btn btn-primary btn-form' %>
               </div>
             <% end %>
           <% else %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -31,21 +31,21 @@
     <%= f.select :iteration_length, iteration_length_options, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
-  <div class="btn-group actions pull-right">
-    <%= f.submit nil, class: 'btn btn-primary' %>
+  <div class="btn-group actions pull-right clearfix">
+    <%= f.submit nil, class: 'btn btn-primary btn-form' %>
 
     <% if policy(@project).archive? %>
       <%= link_to t('projects.archive'), [:archive, @project],
         data: {confirm: t('projects.index.are you sure you want to archive this project')},
         method: :patch,
-        class: 'btn btn-warning' %>
+        class: 'btn btn-warning btn-form' %>
     <% end %>
 
     <% if policy(@project).destroy? %>
       <%= link_to t('delete'), @project,
         data: {confirm: t('projects.index.are you sure you want to delete this project')},
         method: :delete,
-        class: 'btn btn-danger' %>
+        class: 'btn btn-danger btn-form' %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,35 +1,34 @@
-<div class="form-wrapper">
 <%= form_for(@project) do |f| %>
   <%= render 'form_errors', object: @project if @project.errors.any? %>
 
-  <div class="field-wrapper">
-    <%= f.label :name, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8"><%= f.text_field :name %></div>
+  <div class="form-group">
+    <%= f.label :name, class: 'control-label' %>
+    <%= f.text_field :name, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :point_scale, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8"><%= f.select :point_scale, point_scale_options %></div>
+  <div class="form-group">
+    <%= f.label :point_scale %>
+    <%= f.select :point_scale, point_scale_options, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :default_velocity, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8"><%= f.text_field :default_velocity, length: 2, size: 3 %></div>
+  <div class="form-group">
+    <%= f.label :default_velocity, class: 'control-label' %>
+    <%= f.text_field :default_velocity, length: 2, size: 3, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper date-wrapper">
-    <%= f.label :start_date, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8 date-select-wrapper"><%= f.date_select :start_date %></div>
+  <div class="form-group date-form-group">
+    <%= f.label :start_date, class: 'control-label' %> <br>
+    <%= f.date_select :start_date, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :iteration_start_day, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8"><%= f.select :iteration_start_day, day_name_options %></div>
+  <div class="form-group ">
+    <%= f.label :iteration_start_day, class: 'control-label' %>
+    <%= f.select :iteration_start_day, day_name_options, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :iteration_length, class: 'col-sm-4 control-label' %>
-    <div class="col-sm-8"><%= f.select :iteration_length, iteration_length_options %></div>
+  <div class="form-group">
+    <%= f.label :iteration_length, class: 'control-label' %>
+    <%= f.select :iteration_length, iteration_length_options, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
   <div class="btn-group actions pull-right">
@@ -50,4 +49,3 @@
     <% end %>
   </div>
 <% end %>
-</div>

--- a/app/views/projects/_share_form.html.erb
+++ b/app/views/projects/_share_form.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="btn-group actions pull-right">
-    <%= f.submit t('projects.share'), class: 'btn btn-primary' %>
+    <%= f.submit t('projects.share'), class: 'btn btn-primary btn-form' %>
   </div>
 <% end %>
 </div>
@@ -25,7 +25,7 @@
           <%= link_to t('projects.unshare'), ownership_project_path(@project, ownership_action: 'unshare', project: { slug: ownership.team.slug }),
             data: {confirm: t('projects.index.are you sure you want to unshare this project')},
             method: :patch,
-            class: 'btn btn-warning' %>
+            class: 'btn btn-warning btn-form' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/projects/_transfer_form.html.erb
+++ b/app/views/projects/_transfer_form.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="btn-group actions pull-right">
-    <%= f.submit t('projects.transfer'), class: 'btn btn-danger', data: { confirm: t("projects.transfer_sure") } %>
+    <%= f.submit t('projects.transfer'), class: 'btn btn-danger btn-form', data: { confirm: t("projects.transfer_sure") } %>
   </div>
 <% end %>
 </div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -23,7 +23,7 @@
     </div>
 
     <div class="card panel">
-      <div class="panel-content">
+      <div class="panel-body">
         <%= render 'form' %>
       </div>
     </div>
@@ -44,7 +44,7 @@
         <div class="panel-heading">
           <%= t('projects.transfer project') %>
         </div>
-        <div class="panel-content transfer-project">
+        <div class="panel-body transfer-project">
           <%= render 'transfer_form' %>
         </div>
       </div>

--- a/app/views/projects/import.html.erb
+++ b/app/views/projects/import.html.erb
@@ -47,7 +47,7 @@
               <%= f.attachinary_file_field :import %>
             </div>
             <div class="field submit">
-              <%= f.submit t('import'), class: 'btn btn-default btn-primary' %>
+              <%= f.submit t('import'), class: 'btn btn-default btn-primary btn-form' %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,10 +1,9 @@
 <% content_for :title_bar do %>
-  <span class="navbar-brand"><%= t('projects.new project') %></span>
-  <%= link_to t('back'), @project, class: 'btn btn-primary btn-sm navbar-btn' %>
+  <%= link_to t('back'), @project, class: "btn btn-primary btn-sm navbar-btn" %>
 <% end %>
 
 <div class="row">
-  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+  <div class="col-xs-12 col-sm-5 col-sm-offset-2">
     <div class="page-header">
       <h4 class="page-header-title darkgrey-2">
         <%= t('projects.new project') %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,11 +1,21 @@
 <% content_for :title_bar do %>
-  <%= link_to t('back'), @project, class: "btn btn-primary btn-sm navbar-btn" %>
+  <span class="navbar-brand"><%= t('projects.new project') %></span>
+  <%= link_to t('back'), @project, class: 'btn btn-primary btn-sm navbar-btn' %>
 <% end %>
 
 <div class="row">
-  <div class="col-sm-12 col-md-6">
-    <h2><%= t('projects.new project') %></h2>
-
-    <%= render 'form' %>
+  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+    <div class="page-header">
+      <h4 class="page-header-title darkgrey-2">
+        <%= t('projects.new project') %>
+      </h4>
+    </div>
+  </div>
+  <div class="col-xs-12 col-sm-5 col-sm-offset-2">
+    <div class="panel card">
+      <div class="panel-body">
+        <%= render 'form' %>
+      </div>
+    </div>
   </div>
 </div>

--- a/spec/features/keycut_spec.rb
+++ b/spec/features/keycut_spec.rb
@@ -42,11 +42,13 @@ describe "Keycuts" do
     end
 
     it 'adds story (a)', js: true do
+      wait_page_load
       send_keys 'a'
       expect(page).to have_css('.story.feature.unscheduled.unestimated.editing')
     end
 
     it 'saves currently open story (<ctl> + s)', js: true do
+      wait_page_load
       click_on 'Add story'
       within('#chilly_bin') do
         fill_in 'title', with: 'New story'

--- a/spec/features/stories_spec.rb
+++ b/spec/features/stories_spec.rb
@@ -19,8 +19,8 @@ describe "Stories" do
       visit project_path(project)
       wait_spinner
 
+      wait_page_load
       click_on 'Add story'
-
       within('#chilly_bin') do
         fill_in 'title', with: 'New story'
         click_on 'Save'

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -48,5 +48,4 @@ module IntegrationHelpers
   def wait_page_load
     find('.column_header', match: :first).click
   end
-
 end

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -45,4 +45,8 @@ module IntegrationHelpers
     expect(page).not_to have_css('.loading-spin.show')
   end
 
+  def wait_page_load
+    find('.column_header', match: :first).click
+  end
+
 end


### PR DESCRIPTION
- [x] Moves New Project page content to a panel.
- [x] Match projects form with other forms. 
- [x] Fix a positioning bug on the Integrations page.
- [x] Fix initial column sizes at the projects board

#### Tests causing build to fail [(fixed on (5c4a5fbe63))](https://github.com/Codeminer42/cm42-central/pull/110/commits/5c4a5fbe632d36d8317506eef689696c8db52d55)
There were a couple recurrent tests failing the builds. Apparently, adding the line `first('.column_header').click` was able to allow the page to load and the tests to pass more frequently. 
Increasing the `Capybara.default_max_wait_time` was not making any difference.

### Before
![extrablankspace](https://cloud.githubusercontent.com/assets/5242693/22748469/f59f03a6-ee08-11e6-894b-d5680f670daa.png)
![old_newproject](https://cloud.githubusercontent.com/assets/5242693/22468338/a822a9f6-e7a6-11e6-95d0-d2f6aa22d2e8.png)

### After
![newproject](https://cloud.githubusercontent.com/assets/5242693/22468124/048c0c2e-e7a6-11e6-8de6-775030fb1791.png)
