### PR TITLE
Edit password and Project reports page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,16 @@
 ## [Unreleased]
 ### Added
 - Added a changelog. We will keep tracking from now and on!
+- Added translations on reports description. 
+
+### Changed
+- Redesign project reports and edit password pages.
+
+### Fixed 
+- Fix a locale select bug to make the options visible on a dark navbar.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
 [Unreleased]: https://github.com/Codeminer42/cm42-central/compare/master...HEAD
+ 

--- a/app/assets/javascripts/global_listeners.js
+++ b/app/assets/javascripts/global_listeners.js
@@ -102,7 +102,7 @@ $(function() {
 
   $('.tag-tooltip').tooltip();
 
-  $('.locale-change').on('change', function(e) {
+  $('.locale-change-select').on('change', function(e) {
     e.preventDefault();
 
     $(this).parent().parent('form').submit();

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -101,41 +101,6 @@
     color: $darkgrey-2;
   }
 
-  &-locale {
-    margin: 15px 10px;
-    font-size: 14px;
-    color: $darkgrey-6;
-
-    .locale-change {
-      position: relative;
-      padding: 0 20px 0 0;
-      background-color: transparent;
-      border: none;
-      border-radius: 0;
-      appearance: none;
-    }
-
-    .locale-change-wrapper {
-      position: relative;
-
-      &:after {
-        content: '';
-        position: absolute;
-        top: 9px;
-        right: 5px;
-        display: inline-block;
-        width: 0;
-        height: 0;
-        vertical-align: middle;
-        border-top: 4px dashed;
-        border-top: 4px solid \9;
-        border-right: 4px solid transparent;
-        border-left: 4px solid transparent;
-        pointer-events: none;
-      }
-    }
-  }
-
   .dropdown {
     margin: 8px 0;
 
@@ -179,5 +144,37 @@
 
   @media (min-width: 768px) {
     margin-right: 0;
+  }
+}
+
+.locale-change {
+  &-wrapper {
+    position: relative;
+
+    &:after {
+      content: '';
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      display: inline-block;
+      width: 0;
+      height: 0;
+      vertical-align: middle;
+      border-top: 4px dashed;
+      border-top: 4px solid \9;
+      border-right: 4px solid transparent;
+      border-left: 4px solid transparent;
+      pointer-events: none;
+    }
+  }
+
+  &-select {
+    padding-right: 31px;
+    appearance: none;
+    -moz-appearance: none;
+
+    .locale-change-option {
+      color: $darkgrey-10;
+    }
   }
 }

--- a/app/assets/stylesheets/_project-reports.scss
+++ b/app/assets/stylesheets/_project-reports.scss
@@ -1,0 +1,24 @@
+.reports-list-item {
+  display: inline;
+
+  .nav-link {
+    color: $darkgrey-6;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+
+    &:hover {
+      border-radius: 4px;
+    }
+  }
+}
+
+.reports-page-actions {
+  font-weight: 600;
+  float: right;
+
+  .navbar-btn-reports {
+    margin: 0;
+    margin-left: 15px;
+  }
+}

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -627,8 +627,9 @@ div#keycut-help {
   margin-top: 20px;
   padding-bottom: 0;
 
-  .page-header-title {
+  &-title {
     font-weight: 600;
+    color: $darkgrey-2;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,4 @@
 @import "menu";
 @import "loading-spin";
 @import "form";
+@import "project-reports";

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,18 +1,19 @@
 class LocalesController < ApplicationController
   skip_before_filter :check_team_presence
 
-  LOCALES = {
-    'English'    => 'en',
-    'Español'    => 'es',
-    'Português'  => 'pt-BR'
-  }
+  options = { :class => 'locale-change-option' }
+  LOCALES = [
+    [ 'English', 'en', options ],
+    [ 'Español', 'es', options ],
+    [ 'Português', 'pt-BR', options ]
+  ]
 
   skip_before_filter :authenticate_user!, only: [:update]
   skip_after_filter :verify_authorized, only: [:update]
   skip_after_filter :verify_policy_scoped, only: [:update]
 
   def update
-    if LOCALES.values.include?(params[:locale])
+    if LOCALES.any? { |locale| locale.include?(params[:locale]) }
       session[:locale] = params[:locale]
     end
     redirect_to request.referer || root_path

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -101,4 +101,8 @@ module ProjectsHelper
       initial_points += points_per_day
     end
   end
+
+  def formatted_standard_deviation(standard_deviation)
+    "%3.2f" % Math.sqrt(standard_deviation)
+  end
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,31 +1,35 @@
 <% content_for :title_bar do %>
   <span class="navbar-brand"><%= t('.change_your_password') %></span>
 <% end %>
+
 <div class="row">
-  <div class="col-sm-12 col-md-6">
-    <div class="form-wrapper">
+  <div class="col-sm-12 col-md-6 col-lg-4 col-md-offset-3 col-lg-offset-4">
+    <div class="auth-wrapper">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
         <%= devise_error_messages! %>
         <%= f.hidden_field :reset_password_token %>
 
-        <div class="field-wrapper">
+        <div class="auth-form-group">
           <%= f.label :password, t('.new_password') %>
           <% if @minimum_password_length %>
             <em>(<%= @minimum_password_length %> characters minimum)</em><br />
           <% end %>
-          <div class="field"><%= f.password_field :password, autofocus: true, autocomplete: "off" %></div>
+          <%= f.password_field :password, autofocus: true, autocomplete: "off", class: 'form-control auth-form-control' %>
         </div>
 
-        <div class="field-wrapper">
+        <div class="auth-form-group">
           <%= f.label :password_confirmation, t('.confirm_new_password') %>
-          <div class="field"><%= f.password_field :password_confirmation, autocomplete: "off" %></div>
+          <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control auth-form-control' %>
         </div>
 
-        <div class="actions"><%= f.submit t('.confirm_new_password'), class: 'btn btn-primary pull-right' %></div>
+        <div class="actions clearfix">
+          <%= f.submit t('.confirm_new_password'), class: 'btn btn-primary pull-right auth-button-submit' %>
+        </div>
       <% end %>
     </div>
   </div>
-  <div class="col-sm-12 col-md-6">
+
+  <div class="col-sm-12 col-md-6 col-lg-4 col-md-offset-3 col-lg-offset-4">
     <%= render partial: "devise/shared/links" %>
   </div>
 </div>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -17,7 +17,7 @@
 <div class="settings-page">
   <div class="col-xs-12 col-sm-9">
     <div class="page-header">
-      <h4 class="page-header-title darkgrey-2">
+      <h4 class="page-header-title">
         <i class="mi md-20">device_hub</i> <%= t('projects.integrations') %>
       </h4>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,11 +31,11 @@
         <div class="navbar-right">
           <%= yield :right_menu %>
 
-          <%= form_tag locales_path, method: :put, class: "navbar-form navbar-left navbar-locale" do  %>
+          <%= form_tag locales_path, method: :put, class: "dropdown" do %>
             <div class="locale-change-wrapper">
               <%= select_tag 'locale',
                   options_for_select(LocalesController::LOCALES, I18n.locale),
-                  class: 'locale-change language-dropdown' %>
+                  class: 'btn btn-link locale-change-select' %>
             </div>
           <% end %>
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -17,7 +17,7 @@
 <div class="settings-page">
   <div class="col-xs-12 col-sm-9">
     <div class="page-header">
-      <h4  class="page-header-title darkgrey-2">
+      <h4  class="page-header-title">
         <i class="mi md-20">edit</i> <%= t('projects.edit project') %>
       </h4>
     </div>

--- a/app/views/projects/import.html.erb
+++ b/app/views/projects/import.html.erb
@@ -17,7 +17,7 @@
 <div class="settings-page">
   <div class="col-xs-12 col-sm-9">
     <div class="page-header">
-      <h4 class="page-header-title darkgrey-2">
+      <h4 class="page-header-title">
         <i class="mi md-20">file_upload</i> <%= t('projects.uploads.title') %>
       </h4>
     </div>

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -4,17 +4,6 @@
       <%= link_to @project.name, @project %>
     </li>
   </ul>
-
-  <% since_options.each do |qty| %>
-    <% if params[:since] == qty.to_s %>
-      <%= link_to t("projects.reports.n months ago", count: qty), "#", class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
-    <% else %>
-      <%= link_to t("projects.reports.n months ago", count: qty), reports_project_path(@project, since: qty), class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
-    <% end %>
-  <% end %>
-  <% if params[:since].present? %>
-    <%= link_to t('projects.reports.all_time'), reports_project_path(@project), class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
-  <% end %>
 <% end %>
 
 <% content_for :navbar do %>
@@ -22,64 +11,136 @@
 <% end %>
 
 <div class="row">
-  <div class="col-sm-12 col-md-12">
-    <% calculate_and_render_burn_up! %>
-
-    <h3><%= t('projects.reports.burn_up') %></h3>
-    <p>The current backlog has a total of <strong><%= @total_backlog_points %> points</strong>. This is without counting the stories in the Chilly Bean!</p>
-    <p>At the current velocity (<%= @service.velocity %> points) the existing backlog should only be finished around the iteration <%= last_iteration_number %> (<%= last_iteration_start_date %>).</p>
-
-    <% if last_iteration_number == last_iteration_number(true) %>
-      <p>If the velocity keeps up this pace we should be on track to the date above.</p>
-    <% else %>
-      <p>But with a standard deviation of <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, it's more realistic to expect the project to finish around <strong>iteration <%= last_iteration_number(true) %></strong> (<%= last_iteration_start_date(true) %>), if the velocity doesn't increase or the backlog is not simplified.</p>
-    <% end %>
-
-    <p><%= area_chart @group_by_day, max: @total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
-
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-12 col-md-12">
-
-    <div class="col-sm-6 col-md-6">
-      <h3><%= t('projects.reports.current_iteration') %> <small>(<%= current_iteration_start_date %> - <%= current_iteration_end_date %>)</small></h3>
-
-      <p>This iteration has <%= current_iteration_points %> points planned in <%= current_iteration_count %> stories (including <%= current_iteration_non_estimable %> bugs or chores).</p>
-
-      <p>There are <%= accepted_points %> points accepted so far, which is <%= accepted_rate %> of the total.</p>
-
-      <p><%= column_chart @service.current_iteration_details, xtitle: t('projects.reports.story_states'), ytitle: t('projects.reports.points') %></p>
-    </div>
-
-    <div class="col-sm-6 col-md-6">
-      <h3><%= t('projects.reports.velocity_by_iteration') %></h3>
-
-      <ul>
-        <li><%= Project.human_attribute_name(:start_date) %>: <%= @project.start_date.to_date %> (<%= I18n.t('date.day_names')[@project.iteration_start_day] %>)</li>
-        <li><%= Project.human_attribute_name(:iteration_length) %>: <%= t('n weeks', count: @project.iteration_length) %></li>
-        <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
-      </ul>
-
-      <p><%= column_chart @service.group_by_velocity, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity'), colors: ['green'] %></p>
+  <div class="col-xs-12">
+    <div class="page-header">
+      <h4 class="page-header-title darkgrey-2">
+        <%= t('reports') %>
+      </h4>
     </div>
   </div>
 </div>
 
 <div class="row">
-  <div class="col-sm-12 col-md-12">
+  <div class="col-xs-12">
+    <div class="panel panel-default card">
+      <div class="panel-body">
+        <ul class="nav nav-justified nav-pills reports-list col-xs-12" id="reports-list">
+          <li class="reports-list-item">
+            <a href="#burn-up" class="nav-link"> <%= t('projects.reports.burn_up') %> </a>
+          </li>
+          <li class="reports-list-item">
+            <a href="#current-iteration" class="nav-link"> <%= t('projects.reports.current_iteration') %></a>
+          </li>
+          <li class="reports-list-item">
+            <a href="#velocity-by-iteration" class="nav-link"> <%= t('projects.reports.velocity_by_iteration') %></a>
+          </li>
+          <li class="reports-list-item">
+            <a href="#velocity-by-member" class="nav-link"> <%= t('projects.reports.velocity_by_member') %></a>
+          </li>
+          <li class="reports-list-item">
+            <a href="#bugs-impact" class="nav-link"> <%= t('projects.reports.bugs_impact') %></a>
+          </li>
+        </ul>
+      </div>
 
-    <div class="col-sm-6 col-md-6">
-      <h3><%= t('projects.reports.velocity_per_member') %></h3>
-      <p><%= line_chart @service.group_by_developer, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity') %></p>
+      <div class="panel-footer clearfix reports-filters">
+        <div class="reports-page-actions">
+          <% unless params[:since].nil? %>
+            <%= t("projects.reports.n months ago", count: params[:since].to_i ) %>
+            <%= link_to t('projects.reports.all_time'), reports_project_path(@project), class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
+          <% end %>
+
+          <% since_options.each do |qty| %>
+            <% if params[:since] == qty.to_s %>
+              <%= link_to t("projects.reports.n months ago", count: qty), "#", class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
+            <% else %>
+              <%= link_to t("projects.reports.n months ago", count: qty), reports_project_path(@project, since: qty), class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
     </div>
+  </div>
+</div>
 
-    <div class="col-sm-6 col-md-6">
-      <h3><%= t('projects.reports.bugs_impact') %></h3>
+<div class="row">
+  <div class="col-xs-12">
+    <div class="panel panel-default card" id="burn-up">
+      <div class="panel-heading"> <%= t('projects.reports.burn_up') %> </div>
+      <div class="panel-body">
+        <% calculate_and_render_burn_up! %>
 
-      <p><%= column_chart @service.group_by_bugs, xtitle: t('projects.reports.iteration_number'), ytitle: t('projects.reports.quantity_non_estimable'), colors: ['red'] %></p>
+        <p>The current backlog has a total of <strong><%= @total_backlog_points %> points</strong>. This is without counting the stories in the Chilly Bean!</p>
+        <p>At the current velocity (<%= @service.velocity %> points) the existing backlog should only be finished around the iteration <%= last_iteration_number %> (<%= last_iteration_start_date %>).</p>
+
+        <% if last_iteration_number == last_iteration_number(true) %>
+          <p>If the velocity keeps up this pace we should be on track to the date above.</p>
+        <% else %>
+          <p>But with a standard deviation of <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, it's more realistic to expect the project to finish around <strong>iteration <%= last_iteration_number(true) %></strong> (<%= last_iteration_start_date(true) %>), if the velocity doesn't increase or the backlog is not simplified.</p>
+        <% end %>
+
+        <p><%= area_chart @group_by_day, max: @total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
+      </div>
     </div>
+  </div>
+</div>
 
+<div class="row">
+  <div class="col-xs-12 col-sm-6">
+    <div class="panel panel-default card" id="current-iteration">
+      <div class="panel-heading">
+        <%= t('projects.reports.current_iteration') %>
+        <small> (<%= current_iteration_start_date %> - <%= current_iteration_end_date %>) </small>
+      </div>
+
+      <div class="panel-body">
+        <p>This iteration has <%= current_iteration_points %> points planned in <%= current_iteration_count %> stories (including <%= current_iteration_non_estimable %> bugs or chores).</p>
+
+        <p>There are <%= accepted_points %> points accepted so far, which is <%= accepted_rate %> of the total.</p>
+
+        <p><%= column_chart @service.current_iteration_details, xtitle: t('projects.reports.story_states'), ytitle: t('projects.reports.points') %></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-sm-6">
+    <div class="panel panel-default card" id="velocity-by-iteration">
+      <div class="panel-heading">
+        <%= t('projects.reports.velocity_by_iteration') %>
+      </div>
+
+      <div class="panel-body">
+        <ul>
+          <li><%= Project.human_attribute_name(:start_date) %>: <%= @project.start_date.to_date %> (<%= I18n.t('date.day_names')[@project.iteration_start_day] %>)</li>
+          <li><%= Project.human_attribute_name(:iteration_length) %>: <%= t('n weeks', count: @project.iteration_length) %></li>
+          <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
+        </ul>
+
+        <p><%= column_chart @service.group_by_velocity, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity'), colors: ['green'] %></p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-xs-12 col-sm-6">
+    <div class="panel panel-default card" id="velocity-by-member">
+      <div class="panel-heading">
+        <%= t('projects.reports.velocity_per_member') %>
+      </div>
+      <div class="panel-body">
+        <p><%= line_chart @service.group_by_developer, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity') %></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <div class="panel panel-default card" id="bugs-impact">
+      <div class="panel-heading">
+        <%= t('projects.reports.bugs_impact') %>
+      </div>
+      <div class="panel-body">
+        <p><%= column_chart @service.group_by_bugs, xtitle: t('projects.reports.iteration_number'), ytitle: t('projects.reports.quantity_non_estimable'), colors: ['red'] %></p>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -26,19 +26,19 @@
       <div class="panel-body">
         <ul class="nav nav-justified nav-pills reports-list col-xs-12">
           <li class="reports-list-item">
-            <a href="#burn-up" class="nav-link"> <%= t('projects.reports.burn_up') %> </a>
+            <a href="#burn-up" class="nav-link"> <%= t('projects.reports.burn_up.title') %> </a>
           </li>
           <li class="reports-list-item">
-            <a href="#current-iteration" class="nav-link"> <%= t('projects.reports.current_iteration') %></a>
+            <a href="#current-iteration" class="nav-link"> <%= t('projects.reports.current_iteration.title') %></a>
           </li>
           <li class="reports-list-item">
-            <a href="#velocity-by-iteration" class="nav-link"> <%= t('projects.reports.velocity_by_iteration') %></a>
+            <a href="#velocity-by-iteration" class="nav-link"> <%= t('projects.reports.velocity_by_iteration.title') %></a>
           </li>
           <li class="reports-list-item">
-            <a href="#velocity-by-member" class="nav-link"> <%= t('projects.reports.velocity_by_member') %></a>
+            <a href="#velocity-by-member" class="nav-link"> <%= t('projects.reports.velocity_by_member.title') %></a>
           </li>
           <li class="reports-list-item">
-            <a href="#bugs-impact" class="nav-link"> <%= t('projects.reports.bugs_impact') %></a>
+            <a href="#bugs-impact" class="nav-link"> <%= t('projects.reports.bugs_impact.title') %></a>
           </li>
         </ul>
       </div>
@@ -66,17 +66,27 @@
 <div class="row">
   <div class="col-xs-12">
     <div class="panel panel-default card" id="burn-up">
-      <div class="panel-heading"> <%= t('projects.reports.burn_up') %> </div>
+      <div class="panel-heading"> <%= t('projects.reports.burn_up.title') %> </div>
       <div class="panel-body">
         <% calculate_and_render_burn_up! %>
 
-        <p>The current backlog has a total of <strong><%= @total_backlog_points %> points</strong>. This is without counting the stories in the Chilly Bean!</p>
-        <p>At the current velocity (<%= @service.velocity %> points) the existing backlog should only be finished around the iteration <%= last_iteration_number %> (<%= last_iteration_start_date %>).</p>
+        <p><%= t('projects.reports.burn_up.backlog_points_html', count: @total_backlog_points) %></p>
+        <p>
+          <%= t('projects.reports.burn_up.remaining_time',
+                velocity: @service.velocity,
+                last_iteration_number: last_iteration_number,
+                last_iteration_start_date: last_iteration_start_date) %>
+        </p>
 
         <% if last_iteration_number == last_iteration_number(true) %>
-          <p>If the velocity keeps up this pace we should be on track to the date above.</p>
+          <p><%= t('projects.reports.burn_up.on_track') %></p>
         <% else %>
-          <p>But with a standard deviation of <%= standard_deviation(@service.standard_deviation) %>, it's more realistic to expect the project to finish around <strong>iteration <%= last_iteration_number(true) %></strong> (<%= last_iteration_start_date(true) %>), if the velocity doesn't increase or the backlog is not simplified.</p>
+          <p>
+            <%= t('projects.reports.burn_up.realistic_remaining_time',
+                  standard_deviation: formatted_standard_deviation(@service.standard_deviation),
+                  last_iteration_number: last_iteration_number(true),
+                  last_iteration_start_date: last_iteration_start_date(true)) %>
+          </p>
         <% end %>
 
         <p><%= area_chart @group_by_day, max: @total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
@@ -89,14 +99,22 @@
   <div class="col-xs-12 col-sm-6">
     <div class="panel panel-default card" id="current-iteration">
       <div class="panel-heading">
-        <%= t('projects.reports.current_iteration') %>
+        <%= t('projects.reports.current_iteration.title') %>
         <small> (<%= current_iteration_start_date %> - <%= current_iteration_end_date %>) </small>
       </div>
 
       <div class="panel-body">
-        <p>This iteration has <%= current_iteration_points %> points planned in <%= current_iteration_count %> stories (including <%= current_iteration_non_estimable %> bugs or chores).</p>
-
-        <p>There are <%= accepted_points %> points accepted so far, which is <%= accepted_rate %> of the total.</p>
+        <p>
+          <%= t('projects.reports.current_iteration.planned_points',
+                points_count: current_iteration_points,
+                stories_count: current_iteration_count,
+                non_estimable_count: current_iteration_non_estimable) %>
+        </p>
+        <p>
+          <%= t('projects.reports.current_iteration.accepted_points',
+                accepted_points: accepted_points,
+                accepted_rate: accepted_rate) %>
+        </p>
 
         <p><%= column_chart @service.current_iteration_details, xtitle: t('projects.reports.story_states'), ytitle: t('projects.reports.points') %></p>
       </div>
@@ -106,14 +124,14 @@
   <div class="col-xs-12 col-sm-6">
     <div class="panel panel-default card" id="velocity-by-iteration">
       <div class="panel-heading">
-        <%= t('projects.reports.velocity_by_iteration') %>
+        <%= t('projects.reports.velocity_by_iteration.title') %>
       </div>
 
       <div class="panel-body">
         <ul>
-          <li><%= Project.human_attribute_name(:start_date) %>: <%= @project.start_date.to_date %> (<%= I18n.t('date.day_names')[@project.iteration_start_day] %>)</li>
+          <li><%= Project.human_attribute_name(:start_date) %>: <%= @project.start_date.to_date %> (<%= t('date.day_names')[@project.iteration_start_day] %>)</li>
           <li><%= Project.human_attribute_name(:iteration_length) %>: <%= t('n weeks', count: @project.iteration_length) %></li>
-          <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= standard_deviation(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
+          <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= formatted_standard_deviation(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
         </ul>
 
         <p><%= column_chart @service.group_by_velocity, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity'), colors: ['green'] %></p>
@@ -126,7 +144,7 @@
   <div class="col-xs-12 col-sm-6">
     <div class="panel panel-default card" id="velocity-by-member">
       <div class="panel-heading">
-        <%= t('projects.reports.velocity_per_member') %>
+        <%= t('projects.reports.velocity_per_member.title') %>
       </div>
       <div class="panel-body">
         <p><%= line_chart @service.group_by_developer, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity') %></p>
@@ -136,7 +154,7 @@
   <div class="col-xs-12 col-sm-6">
     <div class="panel panel-default card" id="bugs-impact">
       <div class="panel-heading">
-        <%= t('projects.reports.bugs_impact') %>
+        <%= t('projects.reports.bugs_impact.title') %>
       </div>
       <div class="panel-body">
         <p><%= column_chart @service.group_by_bugs, xtitle: t('projects.reports.iteration_number'), ytitle: t('projects.reports.quantity_non_estimable'), colors: ['red'] %></p>

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -13,7 +13,7 @@
 <div class="row">
   <div class="col-xs-12">
     <div class="page-header">
-      <h4 class="page-header-title darkgrey-2">
+      <h4 class="page-header-title">
         <%= t('reports') %>
       </h4>
     </div>
@@ -24,7 +24,7 @@
   <div class="col-xs-12">
     <div class="panel panel-default card">
       <div class="panel-body">
-        <ul class="nav nav-justified nav-pills reports-list col-xs-12" id="reports-list">
+        <ul class="nav nav-justified nav-pills reports-list col-xs-12">
           <li class="reports-list-item">
             <a href="#burn-up" class="nav-link"> <%= t('projects.reports.burn_up') %> </a>
           </li>
@@ -45,7 +45,7 @@
 
       <div class="panel-footer clearfix reports-filters">
         <div class="reports-page-actions">
-          <% unless params[:since].nil? %>
+          <% if params[:since] %>
             <%= t("projects.reports.n months ago", count: params[:since].to_i ) %>
             <%= link_to t('projects.reports.all_time'), reports_project_path(@project), class: "btn btn-warning btn-sm navbar-btn navbar-btn-reports" %>
           <% end %>
@@ -76,7 +76,7 @@
         <% if last_iteration_number == last_iteration_number(true) %>
           <p>If the velocity keeps up this pace we should be on track to the date above.</p>
         <% else %>
-          <p>But with a standard deviation of <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, it's more realistic to expect the project to finish around <strong>iteration <%= last_iteration_number(true) %></strong> (<%= last_iteration_start_date(true) %>), if the velocity doesn't increase or the backlog is not simplified.</p>
+          <p>But with a standard deviation of <%= standard_deviation(@service.standard_deviation) %>, it's more realistic to expect the project to finish around <strong>iteration <%= last_iteration_number(true) %></strong> (<%= last_iteration_start_date(true) %>), if the velocity doesn't increase or the backlog is not simplified.</p>
         <% end %>
 
         <p><%= area_chart @group_by_day, max: @total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
@@ -113,7 +113,7 @@
         <ul>
           <li><%= Project.human_attribute_name(:start_date) %>: <%= @project.start_date.to_date %> (<%= I18n.t('date.day_names')[@project.iteration_start_day] %>)</li>
           <li><%= Project.human_attribute_name(:iteration_length) %>: <%= t('n weeks', count: @project.iteration_length) %></li>
-          <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= "%3.2f" % Math.sqrt(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
+          <li><%= t('velocity') %>: <%= @service.velocity %>,  <%= t('standard_deviation') %>: <%= standard_deviation(@service.standard_deviation) %>, <%= t('volatility') %>: <%= number_to_percentage(@service.volatility * 100.0, precision: 2) %></li>
         </ul>
 
         <p><%= column_chart @service.group_by_velocity, xtitle: t('projects.reports.iteration_number'), ytitle: t('velocity'), colors: ['green'] %></p>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-xs-12 col-md-8 col-md-offset-2">
     <div class="page-header">
-      <h4 class="page-header-title darkgrey-2">
+      <h4 class="page-header-title">
         <i class="mi md-20">account_circle</i> <%= t('edit') %> <%= resource.class.name.humanize %>
       </h4>
     </div>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-10 col-md-offset-1">
     <div class="page-header">
-      <h4 class="page-header-title darkgrey-2">
+      <h4 class="page-header-title">
         <i class="mi md-20">dashboard</i> <%= t('teams.select') %>
         <%= link_to t('teams.create'), new_team_path, class: "btn btn-link pull-right unstyled-link" %>
       </h4>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,7 @@
   <% if policy(User).manage? %>
     <div class="col-xs12 col-xs-8 col-sm-offset-2">
       <div class="page-header">
-        <h4 class="page-header-title darkgrey-2">
+        <h4 class="page-header-title">
           <i class="mi md-20">dashboard</i> <%= t('add new member') %>
         </h4>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,11 +198,22 @@ en:
       iteration_number: "Iteration Number"
       quantity_non_estimable: "Quantity of Bugs/Chores"
 
-      current_iteration: "Current Iteration"
-      bugs_impact: "Bugs Impact"
-      velocity_by_iteration: "Velocity by Iteration"
-      velocity_per_member: "Velocity per Member"
-      burn_up: "Burn Up Chart"
+      current_iteration:
+        title: "Current Iteration"
+        planned_points: "This iteration has %{points_count} points planned in %{stories_count} stories (including %{non_estimable_count} bugs or chores)."
+        accepted_points: "There are %{accepted_points} points accepted so far, which is %{accepted_rate} of the total."
+      bugs_impact:
+        title: "Bugs Impact"
+      velocity_by_iteration:
+        title: "Velocity by Iteration"
+      velocity_per_member:
+        title: "Velocity per Member"
+      burn_up:
+        title: "Burn Up Chart"
+        backlog_points_html: "The current backlog has a total of <strong>%{count} points</strong>. This is without counting the stories in the Chilly Bean!"
+        remaining_time: "At the current velocity (%{velocity} points) the existing backlog should only be finished around the iteration %{last_iteration_number} (%{last_iteration_start_date})."
+        on_track: "If the velocity keeps up this pace we should be on track to the date above."
+        realistic_remaining_time: "But with a standard deviation of %{standard_deviation}, it's more realistic to expect the project to finish around <strong>iteration %{last_iteration_number}</strong> (%{last_iteration_start_date}), if the velocity doesn't increase or the backlog is not simplified."
     project properties: "Project Properties"
     archived projects:  "Archived Projects"
     archive: "Archive"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -189,11 +189,22 @@ es:
       iteration_number: "Número de iteración"
       quantity_non_estimable: "Cantidad de Bugs / Tareas"
 
-      current_iteration: "Iteración actual"
-      bugs_impact: "Impacto de los errores"
-      velocity_by_iteration: "Velocidad por iteración"
-      velocity_per_member: "Velocidad por cada miembro"
-      burn_up: "Gráfico de Burn Up"
+      current_iteration:
+        title: "Iteración actual"
+        planned_points: "Esta iteraión tiene %{points_count} puntos planteados en %{stories_count} historias (incluyendo %{non_estimable_count} bugs o chores)."
+        accepted_points: "Hay %{accepted_points} puntos aceptados hasta ahora, lo que significa %{accepted_rate} del total."
+      bugs_impact:
+        title: "Impacto de los errores"
+      velocity_by_iteration:
+        title: "Velocidad por iteración"
+      velocity_per_member:
+        title: "Velocidad por cada miembro"
+      burn_up:
+        title: "Gráfico de Burn Up"
+        backlog_points_html: "El backlog actual tiene un total de <strong>%{count} puntos</strong>. ¡Esto es, sin contar las historias en el Chilly Bin!"
+        remaining_time: "A la velocidad actual (%{velocity} puntos) el backlog actual sólo se debe terminar alrededor de la iteración %{last_iteration_number} (%{last_iteration_start_date})."
+        on_track: "Si la velocidad sigue este ritmo, deberemos estar en camino a la fecha prevista."
+        realistic_remaining_time: "Pero con una desviación estándar de %{standard_deviation}, es más realista esperar que el proyecto termine alrededor de la <strong>iteración %{last_iteration_number}</strong> (%{last_iteration_start_date}), si la velocidad no aumenta o el backlog no se simplifica."
     project properties: "Propiedades del Proyecto"
     archived projects:  "Proyectos archivados"
     archive: "Archivar"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -200,11 +200,22 @@ pt-BR:
       iteration_number: "Número da Iteração"
       quantity_non_estimable: "Quantidade de Bugs/Chores"
 
-      current_iteration: "Iteração Atual"
-      bugs_impact: "Impacto dos Bugs"
-      velocity_by_iteration: "Velocidade por Iteração"
-      velocity_per_member: "Velocidade por Membro"
-      burn_up: "Gráfico de Burn Up"
+      current_iteration:
+        title: "Iteração Atual"
+        planned_points: "Esta iteração tem %{points_count} pontos planejados em %{stories_count} histórias (incluindo %{non_estimable_count} bugs ou chores)."
+        accepted_points: "Existem %{accepted_points} pontos aceitos até agora, o que é %{accepted_rate} do total."
+      bugs_impact:
+        title: "Impacto dos Bugs"
+      velocity_by_iteration:
+        title: "Velocidade por Iteração"
+      velocity_per_member:
+        title: "Velocidade por Membro"
+      burn_up:
+        title: "Gráfico de Burn Up"
+        backlog_points_html: "O backlog atual contém um total de <strong>%{count} pontos</strong>. Isto é, se não contarmos com as hitórias na Chilly Bin!"
+        remaining_time: "Na atual velocidade (%{velocity} pontos) o backlog existente deve ser finalizado somente por volta da iteração %{last_iteration_number} (%{last_iteration_start_date})."
+        on_track: "Se a velocidade continuar estável, estaremos bem encaminhados para entregar o projeto na data acima."
+        realistic_remaining_time: "No entanto, com o desvio padrão de %{standard_deviation}, é mais realista esperar que o projeto seja finalizado por volta da <strong>iteração %{last_iteration_number}</strong> (%{last_iteration_start_date}), se não houver aumento na velocidade ou uma simplificação do backlog."
     project properties: "Propriedades do Projeto"
     archived projects:  "Projetos Arquivados"
     archive: "Arquivar"


### PR DESCRIPTION
- [x] Redesign project reports and edit password pages. 
- [x] Uses translations on reports description
- [x] Fix a locale select bug that would iherit the white text color and make its options invisible on a dark navbar
 
### Before
![oldeditpassword](https://cloud.githubusercontent.com/assets/5242693/22647728/fb3c584e-ec51-11e6-8318-2c6e06edcd1b.png)
![oldreports](https://cloud.githubusercontent.com/assets/5242693/22647729/fb3f5602-ec51-11e6-82a5-63f27f7c1455.png)

### After
![neweditpassword](https://cloud.githubusercontent.com/assets/5242693/22647738/04aafc14-ec52-11e6-903d-ee181f77faf7.png)
![newreports](https://cloud.githubusercontent.com/assets/5242693/22647892/985f7a20-ec52-11e6-80e5-bf3ecf345c75.png)
