### PR TITLE
Fix positioning problems on Project Settings page

### DIFF
--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -105,11 +105,9 @@ module.exports = Backbone.View.extend({
 
   scaleToViewport: function() {
     var viewSize = $('.content-wrapper').height();
-    var offsetTop = $('.project-stories').offset().top;
     var columnHeaderSize = $('.column_header:first').outerHeight();
-    var extra = parseInt($('.project-stories').css('padding-top'));
 
-    var height = viewSize - columnHeaderSize - offsetTop - extra;
+    var height = viewSize - columnHeaderSize;
 
     $('.storycolumn').css('height', height + 'px');
 

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -5,6 +5,7 @@ body {
 }
 
 .container-fluid {
+  height: 100%;
   padding-left: 0;
   padding-right: 0;
 

--- a/app/assets/stylesheets/_project-settings.scss
+++ b/app/assets/stylesheets/_project-settings.scss
@@ -1,7 +1,8 @@
 /* Settings */
 .settings-page {
   background: $lightgrey-7;
-  padding: 0  30px;
+  height: 100%;
+  padding: 0 30px;
   overflow-y: auto;
 }
 

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -71,6 +71,7 @@ ul#primary-nav li {
 }
 
 .main {
+  height: 100%;
   margin: 0;
   position: relative;
 }
@@ -98,6 +99,8 @@ table.stories td {
 div.storycolumn {
   overflow: auto;
   padding-bottom: 80px;
+  border-right: 1px solid $black;
+  border-left: 1px solid $black;
 }
 
 /* Story columns headers */

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <div class="btn-group actions">
-    <%= f.submit @team.new_record? ? t('teams.create') : t('teams.update'), class: 'btn btn-primary' %>
+    <%= f.submit @team.new_record? ? t('teams.create') : t('teams.update'), class: 'btn btn-primary btn-form' %>
   </div>
 <% end %>
 

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,13 +1,23 @@
 <% content_for :title_bar do %>
-  <span class="navbar-brand"><%= t('teams.new team') %></span>
+  <%= link_to t('back'), teams_path, class: "btn btn-primary btn-sm navbar-btn" %>
 <% end %>
 
 <div class="row">
-  <%= render 'form' %>
+  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+    <div class="page-header">
+      <h4 class="page-header-title darkgrey-2">
+        <i class="mi md-20">group</i> <%= t('teams.new team') %>
+      </h4>
+    </div>
+  </div>
 
-  <div class="col-sm-12 col-md-6 col-lg-4 col-md-offset-3 col-lg-offset-4">
-    <div class="auth-actions">
-      <%= raw t('teams.new_instruction') %>
+  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+    <div class="panel panel-default card">
+      <div class="panel-body">
+        <%= render 'form' %>
+        <hr>
+        <%= raw t('teams.new_instruction') %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The Project Settings pages like Import and Integrations which have a smaller height than screen size were broken.

- Fix  the pages below giving `.main` and `.container-fluid` a `height:100%`  so the `.settings-page` can follow their height.
- Add borders on `.storycolumn`, so it matches the `.column_header` size.
- Add redesign to New Team page
 
![old](https://cloud.githubusercontent.com/assets/5242693/22829139/ca8e0ff4-ef7f-11e6-9653-8c59f7c4845f.jpeg)  ![new](https://cloud.githubusercontent.com/assets/5242693/22829141/ce18c42a-ef7f-11e6-964b-59baa582eb1a.jpeg)

<img src="https://cloud.githubusercontent.com/assets/5242693/22829438/6736f748-ef81-11e6-93a1-dd99a21be69b.jpeg" width="700" height="250">
<img src="https://cloud.githubusercontent.com/assets/5242693/22829441/69d09432-ef81-11e6-92dd-58c204a26ec7.jpeg" width="700" height="250">
