### PR TITLE
Admin Users redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Redesign project reports and edit password pages.
+- Redesign Admin Users pages.
 
 ### Fixed 
 - Fix a locale select bug to make the options visible on a dark navbar.

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -30,8 +30,12 @@
   width: auto;
 }
 
-.btn-form {
+.btn-square {
   border-radius: 0;
+}
+
+.btn-form {
+  @extend .btn-square;
   font-size: 14px;
   padding: 7px 20px;
 }

--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -37,3 +37,7 @@
     }
   }
 }
+
+.admin-users-table {
+  tr:first-child td { border: 0; }
+}

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,34 +1,32 @@
-<div class="form-wrapper add-member">
 <%= form_for [:admin, @user] do |f| %>
   <%= render 'form_errors', object: @user if @user.errors.any? %>
 
-  <div class="field-wrapper">
-    <%= f.label :email, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.text_field :email %></div>
+  <div class="form-group">
+    <%= f.label :email, class: 'control-label' %>
+    <%= f.text_field :email, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :name, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.text_field :name %></div>
+  <div class="form-group">
+    <%= f.label :name, class: 'control-label' %>
+    <%= f.text_field :name, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :initials, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.text_field :initials %></div>
+  <div class="form-group">
+    <%= f.label :initials, class: 'control-label' %>
+    <%= f.text_field :initials, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :username, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.text_field :username %></div>
+  <div class="form-group">
+    <%= f.label :username, class: 'control-label' %>
+    <%= f.text_field :username, class: 'form-control auth-form-control' %>
   </div>
 
-  <div class="field-wrapper">
-    <%= f.label :role, class: 'col-sm-2 control-label' %>
-    <div class="col-sm-10"><%= f.select :role, User.role.options %></div>
+  <div class="form-group">
+    <%= f.label :role, class: 'control-label' %>
+    <%= f.select :role, User.role.options, {}, { class: 'form-control auth-form-control' } %>
   </div>
 
-  <div class="actions">
-    <%= f.submit nil, class: 'btn btn-primary pull-right' %>
+  <div class="actions pull-right">
+    <%= f.submit nil, class: 'btn btn-primary btn-form' %>
   </div>
 <% end %>
-</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,33 +1,55 @@
 <% content_for :title_bar do %>
+  <ul class="nav navbar-nav">
+    <li>
+      <%= link_to current_team.name, projects_path %>
+    </li>
+  </ul>
+
   <%= link_to t('back'), admin_users_path, class: "btn btn-primary btn-sm navbar-btn" %>
 <% end %>
 
 <div class="row">
-  <div class="col-sm-12 col-md-6">
-    <h2><%= t('admin.users.edit user') %></h2>
 
-    <%= render 'form' %>
+  <div class="col-xs-12 col-sm-8 col-sm-offset-2">
+    <div class="page-header">
+      <h4 class="page-header-title">
+        <i class="mi md-20">edit</i> <%= t('admin.users.edit user') %>
+      </h4>
+    </div>
   </div>
 
-  <div class="col-sm-12 col-md-6">
-    <h2><%= Project.model_name.human(count: 2) %></h2>
+  <div class="col-xs-12 col-sm-5 col-sm-offset-2">
+    <div class="panel card">
+      <div class="panel-body">
+        <%= render 'form' %>
+      </div>
+    </div>
+  </div>
 
-    <% if @user.projects.count > 0 %>
-      <table class="table table-hover">
-        <% @user.projects.each do |project| %>
-          <tr>
-            <td class="lead"><%= link_to project.name, project %></td>
-            <td>
-              <%= link_to 'Remove', project_user_path(project, @user),
-                method: :delete,
-                class: 'btn btn-danger btn-sm',
-                data: { confirm: 'Are you sure?' } %>
-            </td>
-          </tr>
+  <div class="col-xs-12 c col-sm-3">
+    <div class="panel card">
+      <div class="panel-heading">
+        <%= Project.model_name.human(count: 2) %>
+      </div>
+      <div class="panel-body">
+        <% if @user.projects.count > 0 %>
+          <table class="table table-condensed table-striped table-hover admin-users-table">
+            <% @user.projects.each do |project| %>
+              <tr>
+                <td><%= link_to project.name, project %></td>
+                <td>
+                  <%= link_to 'Remove', project_user_path(project, @user),
+                    method: :delete,
+                    class: 'btn btn-danger btn-sm btn-square pull-right',
+                    data: { confirm: t('admin.users.edit.remove from project confirmation') } %>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        <% else %>
+          --
         <% end %>
-      </table>
-    <% else %>
-      --
-    <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,40 +1,60 @@
-<div class="row">
-  <div class="col-sm-12">
-    <h2><%= t('all users') %></h2>
+<% content_for :title_bar do %>
+  <ul class="nav navbar-nav">
+    <li>
+      <%= link_to current_team.name, projects_path %>
+    </li>
+  </ul>
+<% end %>
 
-    <table class="table table-hover">
-      <% @users.order(:name).each do |user| %>
-        <tr>
-          <td><%= user.name %></td>
-          <td><%= user.username %></td>
-          <td><%= user.initials %></td>
-          <td><%= user.role %></td>
-          <td><%= link_to user.email, "mailto:#{user.email}" %></td>
-          <td>
-            <div class="users_options btn-group pull-right">
-              <% if policy(user).update? %>
-                <%= link_to t('edit'), edit_admin_user_path(user),
-                  class: 'btn btn-default btn-sm' %>
-                <% if current_team.is_admin?(user) %>
-                  <%= link_to t('users.admin_off'), enrollment_admin_user_path(user, is_admin: false),
-                    data: {confirm: t('.are you sure you want to remove administration rights from this user')},
-                    method: :patch,
-                    class: 'btn btn-warning btn-sm' %>
-                <% else %>
-                  <%= link_to t('users.admin_on'), enrollment_admin_user_path(user, is_admin: true),
-                    data: {confirm: t('.are you sure you want to give administration rights to this user')},
-                    method: :patch,
-                    class: 'btn btn-primary btn-sm' %>
-                <% end %>
-                <%= link_to t('delete'), admin_user_path(user),
-                  data: {confirm: t('.are you sure you want to delete this user')},
-                  method: :delete,
-                  class: 'btn btn-danger btn-sm' %>
-              <% end %>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </table>
+<div class="row">
+  <div class="col-xs-12 col-sm-10 col-sm-offset-1">
+    <div class="page-header">
+      <h4 class="page-header-title">
+        <i class="mi md-20">group</i> <%= t('all users') %>
+      </h4>
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-sm-10 col-sm-offset-1">
+    <div class="panel card">
+      <div class="panel-body">
+        <table class="table table-condensed table-striped table-hover admin-users-table">
+          <tbody>
+            <% @users.order(:name).each do |user| %>
+              <tr>
+                <td><%= user.name %></td>
+                <td><%= user.username %></td>
+                <td><%= user.initials %></td>
+                <td><%= user.role %></td>
+                <td><%= link_to user.email, "mailto:#{user.email}" %></td>
+                <td>
+                  <div class="users_options btn-group pull-right">
+                    <% if policy(user).update? %>
+                      <%= link_to t('edit'), edit_admin_user_path(user),
+                        class: 'btn btn-default btn-sm btn-square' %>
+                      <% if current_team.is_admin?(user) %>
+                        <%= link_to t('users.admin_off'), enrollment_admin_user_path(user, is_admin: false),
+                          data: {confirm: t('.are you sure you want to remove administration rights from this user')},
+                          method: :patch,
+                          class: 'btn btn-warning btn-sm btn-square' %>
+                      <% else %>
+                        <%= link_to t('users.admin_on'), enrollment_admin_user_path(user, is_admin: true),
+                          data: {confirm: t('.are you sure you want to give administration rights to this user')},
+                          method: :patch,
+                          class: 'btn btn-primary btn-sm btn-square' %>
+                      <% end %>
+                      <%= link_to t('delete'), admin_user_path(user),
+                        data: {confirm: t('.are you sure you want to delete this user')},
+                        method: :delete,
+                        class: 'btn btn-danger btn-sm btn-square' %>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title_bar do %>
-  <ul class="nav navbar-nav">
-    <li>
-      <%= link_to current_team.name, projects_path %>
-    </li>
-  </ul>
+  <%= link_to t('back'), edit_team_path(current_team), class: "btn btn-primary btn-sm navbar-btn" %>
 <% end %>
 
 <div class="row">
@@ -26,7 +22,7 @@
                 <td><%= user.username %></td>
                 <td><%= user.initials %></td>
                 <td><%= user.role %></td>
-                <td><%= link_to user.email, "mailto:#{user.email}" %></td>
+                <td><%= mail_to user.email %></td>
                 <td>
                   <div class="users_options btn-group pull-right">
                     <% if policy(user).update? %>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="col-xs-12 col-sm-<%= current_user.teams.count > 1 ? "5" : "8" %> col-sm-offset-2">
+  <div class="col-xs-12 col-sm-5 col-sm-offset-2">
     <div class="panel panel-default card">
       <div class="panel-body">
         <%= render 'form' %>
@@ -55,9 +55,21 @@
     </div>
   </div>
 
+  <div class="col-xs-12 col-sm-3">
+    <div class="panel panel-default card">
+      <div class="panel-body">
+        <% if session[:current_team_slug] && current_team.try(:logo) %>
+          <div class="text-center">
+            <img class="user-image" src="<%= current_team.logo.path %>">
+          </div>
+          <hr />
+        <% end %>
 
-  <% if current_user.teams.count > 1 %>
-    <div class="col-xs-12 col-sm-3">
+        <%= link_to t('teams.members'), admin_users_path, class: 'btn btn-default col-xs-12 btn-square' %>
+      </div>
+    </div>
+
+    <% if current_user.teams.count > 1 %>
       <div class="panel panel-default card">
         <div class="panel-heading">
           <%= t('teams.switch') %>
@@ -70,6 +82,6 @@
           </div>
         </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,7 +295,7 @@ en:
       <p>If you don't have a registered account, you can sign up first.</p>
       <p>The first user to sign in to this new team will become the administrator.</p>
     no_teams_found: "Oops! You're not enrolled to a team yet."
-
+    members: "Manage Team Members"
   admin:
     users:
       edit user: "Edit User"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -303,6 +303,8 @@ en:
         are you sure you want to delete this user: "Are you sure you want to delete this user? This action cannot be undone."
         are you sure you want to remove administration rights from this user: "Are you sure you want to remove administration rights from this user?"
         are you sure you want to give administration rights to this user: "Are you sure you want to give administration rights to this user?"
+      edit:
+        remove from project confirmation: "Are you sure you want to remove the user from this project?"
 
   registrations:
     edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -294,6 +294,8 @@ es:
         are you sure you want to delete this user: "¿Estas seguro de querer borrar este miembro? Esta acción no se puede deshacer."
         are you sure you want to remove administration rights from this user: "¿Está seguro de que desea eliminar los derechos de administración de este usuario?"
         are you sure you want to give administration rights to this user: "¿Está seguro de que desea dar derechos de administrador a este usuario?"
+      edit:
+        remove from project confirmation: "¿Estas seguro de querer borrar este usuario del proyecto?"
 
   registrations:
     edit:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -286,6 +286,7 @@ es:
     new_instruction: |
       <p>Si usted no tiene una cuenta registrada, puede inscribirse en primer lugar.</p>
       <p>El primer usuario que acceda a este nuevo equipo será el administrador.</p>
+    members: "Gestionar los Miembros del Equipo"
 
   admin:
     users:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -294,6 +294,7 @@ pt-BR:
     team was successfully created: 'Equipe foi criado com sucesso'
     team was successfully updated: 'Equipe foi atualizado com sucesso'
     no_teams_found: "Oops! Você ainda não está inscrito em uma equipe."
+    members: "Gerenciar Membros da Equipe"
 
   admin:
     users:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -302,6 +302,8 @@ pt-BR:
         are you sure you want to delete this user: "Tem certeza de que deseja excluir este usuário? Esta ação não pode ser desfeita."
         are you sure you want to remove administration rights from this user: "Tem certeza de que deseja remover direitos de administração deste usuário?"
         are you sure you want to give administration rights to this user: "Tem certeza de que quer dar direitos de administração para este usuário?"
+      edit:
+        remove from project confirmation: "Tem certeza de que deseja excluir o usuário deste projeto?"
 
   registrations:
     edit:


### PR DESCRIPTION
This PR add a couple pages under `admin_user` routes redesign, which were missing from #62.

- [x] redesign pages under `admin_user` routes, which were missing from #62.
- [x] add button on `edit_team` so the users can access those pages

### Before
![oldedit](https://cloud.githubusercontent.com/assets/5242693/22886628/74ad5648-f1dd-11e6-88de-8c1a41d503e9.png)
![oldindex](https://cloud.githubusercontent.com/assets/5242693/22886629/75be2f62-f1dd-11e6-9700-05a633ddaf66.png)

### After
![newedit](https://cloud.githubusercontent.com/assets/5242693/22886633/792cdfb8-f1dd-11e6-97f2-6dc4e8fca69f.png)
![newindex](https://cloud.githubusercontent.com/assets/5242693/22886636/7ae44ee0-f1dd-11e6-9ada-9634da3e7402.png)
