### PR TITLE
Add integrations to Project endpoint

### DIFF
--- a/app/api/entities/integration.rb
+++ b/app/api/entities/integration.rb
@@ -1,0 +1,11 @@
+class Entities::Integration < Entities::BaseEntity
+  expose :id
+  expose :project_id
+  expose :kind
+  expose :data
+
+  with_options(format_with: :iso_timestamp) do
+    expose :created_at, if: lambda { |i, o| i.created_at.present? }
+    expose :updated_at, if: lambda { |i, o| i.updated_at.present? }
+  end
+end

--- a/app/api/entities/project.rb
+++ b/app/api/entities/project.rb
@@ -8,7 +8,8 @@ class Entities::Project < Entities::BaseEntity
   expose :default_velocity
   expose :velocity, if: { type: :full }
   expose :volatility, if: { type: :full }
-  expose :teams
+  expose :teams, using: API::Entities::Team
+  expose :integrations, using: API::Entities::Integration, if: { type: :full } 
 
   with_options(format_with: :iso_timestamp) do
     expose :created_at, if: lambda { |i, o| i.created_at.present? }

--- a/spec/api/entities/integration_spec.rb
+++ b/spec/api/entities/integration_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Entities::Integration do
+  let(:integration) { create :integration }
+
+  subject { described_class.represent(integration).as_json }
+
+  it { expect(subject[:id]).to eq(integration.id) }
+  it { expect(subject[:project_id]).to eq(integration.project_id) }
+  it { expect(subject[:kind]).to eq(integration.kind) }
+  it { expect(subject[:data]).to eq(integration.data) }
+end


### PR DESCRIPTION
When queried a particular project, it now returns the integrations corresponding to the project.