### PR TITLE
Fix bug that keeps save/cancel buttons disabled after a failed upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Fix docker setup for development mode.
+- Fix bug keeping .story-controls disabled after a failed upload.
 
 ## [1.1.1] - 2017-03-14
 ### Changed

--- a/app/assets/javascripts/templates/alert.ejs
+++ b/app/assets/javascripts/templates/alert.ejs
@@ -1,0 +1,7 @@
+<div class="alert alert-dismissible story-alert <%= className %>" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">×</span>
+  </button>
+
+  <%= message %>
+</div>

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -25,7 +25,7 @@ module.exports = FormView.extend({
       "renderNotesCollection", "addEmptyNote", "hoverBox",
       "renderTasks", "renderTasksCollection", "addEmptyTask",
       "clickSave", "attachmentDone", "attachmentStart",
-      "disableControlButtons");
+      "attachmentFail", "disableControlButtons");
 
     // Rerender on any relevant change to the views story
     this.model.on("change", this.render);
@@ -87,7 +87,8 @@ module.exports = FormView.extend({
     "click .toggle-history": "history",
     "sortupdate": "sortUpdate",
     "fileuploaddone": "attachmentDone",
-    "fileuploadstart": "attachmentStart"
+    "fileuploadstart": "attachmentStart",
+    "fileuploadfail": "attachmentFail"
   },
 
   // Triggered whenever a story is dropped to a new position
@@ -746,6 +747,11 @@ module.exports = FormView.extend({
 
   attachmentStart: function() {
     this.uploadInProgress = true;
+    this.disableControlButtons();
+  },
+
+  attachmentFail: function() {
+    this.uploadInProgress = false;
     this.disableControlButtons();
   },
 

--- a/app/assets/stylesheets/_simple-alert.scss
+++ b/app/assets/stylesheets/_simple-alert.scss
@@ -5,3 +5,7 @@
     text-align: center;
   }
 }
+
+.story-alert {
+  margin-top: 10px;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,8 @@ en:
     tasks: "Tasks"
     notes: "Notes"
     attachments: "Attachments"
+    errors:
+      failed_upload: "Your upload has failed. Please try again."
 
     definitive_sure: "Are you sure you want to %{action} this story? This action is irreversible."
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -72,6 +72,8 @@ es:
     tasks: "Tareas"
     notes: "Notas"
     attachments: "Adjuntos"
+    errors:
+      failed_upload: "Error de subida. Vuelva a intentarlo."
 
     definitive_sure: "¿Seguro que deseas %{action} esta historia? Esta acción es irrreversible."
 

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -72,6 +72,8 @@ pt-BR:
     tasks: "Tarefas"
     notes: "Notas"
     attachments: "Anexos"
+    errors:
+      failed_upload: "O upload falhou. Por favor, tente novamente."
 
     definitive_sure: "Tem certeza que deseja %{action} essa história? Essa ações é irreversível."
 

--- a/spec/javascripts/views/story_view_spec.js
+++ b/spec/javascripts/views/story_view_spec.js
@@ -304,26 +304,6 @@ describe('StoryView', function() {
       expect(this.story.setAcceptedAt).toHaveBeenCalledOnce();
     });
 
-    describe("when an attachment is done", function() {
-      beforeEach(function() {
-        this.view.attachmentStart();
-      });
-
-      it("change the uploadInProgress to false", function() {
-        this.server.respondWith(
-          "PUT", "/path/to/story", [
-            200, {"Content-Type": "application/json"},
-            '{"story":{"estimate":"1"}}'
-          ]
-        );
-
-        this.view.saveEdit(this.e);
-
-        this.server.respond();
-
-        expect(this.view.uploadInProgress).toBeFalsy;
-      });
-    });
   });
 
   describe("expand collapse controls", function() {
@@ -673,15 +653,6 @@ describe('StoryView', function() {
 
         expect(this.view.saveEdit).not.toHaveBeenCalled();
       });
-
-      it('update uploadInProgress variable', function() {
-        this.view.model.isNew = sinon.stub().returns(true);
-        this.view.uploadInProgress = true;
-
-        this.view.attachmentDone();
-
-        expect(this.view.uploadInProgress).toBeFalsy();
-      });
     });
 
     describe('when the story is not new', function() {
@@ -698,90 +669,79 @@ describe('StoryView', function() {
 
   describe('attachmentStart', function() {
     describe('while the attachment is happening', function() {
-      it('update the uploadInProgress variable', function() {
+      it('call toggleControlButtons', function() {
+        spyOn(this.view, 'toggleControlButtons')
         this.view.attachmentStart();
-        expect(this.view.uploadInProgress).toBeTruthy;
-      });
-
-      it('call disableControlButtons', function() {
-        spyOn(this.view, 'disableControlButtons')
-        this.view.attachmentStart();
-        expect(this.view.disableControlButtons).toHaveBeenCalled();
+        expect(this.view.toggleControlButtons).toHaveBeenCalled();
       });
     });
   });
 
   describe('attachmentFail', function() {
     describe('when the attachment has failed to upload', function() {
-      it('update the uploadInProgress variable', function() {
+      it('call toggleControlButtons', function() {
+        spyOn(this.view, 'toggleControlButtons')
         this.view.attachmentFail();
-        expect(this.view.uploadInProgress).toBeFalsy;
-      });
-
-      it('call disableControlButtons', function() {
-        spyOn(this.view, 'disableControlButtons')
-        this.view.attachmentFail();
-        expect(this.view.disableControlButtons).toHaveBeenCalled();
+        expect(this.view.toggleControlButtons).toHaveBeenCalled();
       });
     });
   });
 
-  describe('disableControlButtons', function() {
+  describe('toggleControlButtons', function() {
     var $storyControls;
 
     beforeEach(function() {
+      this.view.canEdit = sinon.stub().returns(true);
       this.view.render();
     });
 
     describe('it render a enabled', function() {
       beforeEach(function() {
-        this.view.uploadInProgress = false;
+        this.view.toggleControlButtons(false);
         $storyControls = this.view.$el.find('.story-controls');
       });
 
       it('submit button', function() {
         var submit = $storyControls.find('.submit');
 
-        expect(submit.disabled).toBeFalsy;
+        expect(submit.disabled).toBeFalsy();
       });
 
       it('cancel button', function() {
         var cancel = $storyControls.find('.cancel');
 
-        expect(cancel.disabled).toBeFalsy;
+        expect(cancel.disabled).toBeFalsy();
       });
 
       it('destroy button', function() {
         var destroy = $storyControls.find('.submit');
 
-        expect(destroy.disabled).toBeFalsy;
+        expect(destroy.disabled).toBeFalsy();
       });
     });
 
     describe('it render a disabled', function() {
-      var $storyControls;
-
       beforeEach(function() {
-        this.view.uploadInProgress = true;
+        this.view.toggleControlButtons(true);
         $storyControls = this.view.$el.find('.story-controls');
       });
 
       it('submit button', function() {
         var submit = $storyControls.find('.submit');
 
-        expect(submit.disabled).toBeTruthy;
+        expect(submit.prop('disabled')).toBeTruthy();
       });
 
       it('cancel button', function() {
         var cancel = $storyControls.find('.cancel');
 
-        expect(cancel.disabled).toBeTruthy;
+        expect(cancel.prop('disabled')).toBeTruthy();
       });
 
       it('destroy button', function() {
         var destroy = $storyControls.find('.submit');
 
-        expect(destroy.disabled).toBeTruthy;
+        expect(destroy.prop('disabled')).toBeTruthy();
       });
     });
   });

--- a/spec/javascripts/views/story_view_spec.js
+++ b/spec/javascripts/views/story_view_spec.js
@@ -711,6 +711,21 @@ describe('StoryView', function() {
     });
   });
 
+  describe('attachmentFail', function() {
+    describe('when the attachment has failed to upload', function() {
+      it('update the uploadInProgress variable', function() {
+        this.view.attachmentFail();
+        expect(this.view.uploadInProgress).toBeFalsy;
+      });
+
+      it('call disableControlButtons', function() {
+        spyOn(this.view, 'disableControlButtons')
+        this.view.attachmentFail();
+        expect(this.view.disableControlButtons).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('disableControlButtons', function() {
     var $storyControls;
 


### PR DESCRIPTION
When a Story's attachment upload fails. There was no event notifying
the StoryView that the upload had already finished. So, the
save/delete/cancel buttons would stay disabled until a new attachment
upload had been successfully completed.