### PR TITLE
Fix Projects display alignment

### DIFF
--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -647,6 +647,11 @@ div#keycut-help {
   }
 }
 
+.projects {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .btn-clipboard {
   padding: 4px 12px 5px;
 }


### PR DESCRIPTION
In a display with medium size, the projects is differing its height causing the grid to not align.

![grid_before](https://cloud.githubusercontent.com/assets/6487206/24421261/00202e16-13cc-11e7-9559-c5c6807467dd.png)

![grid_after](https://cloud.githubusercontent.com/assets/6487206/24421271/055181f0-13cc-11e7-9180-55cdd8fcf47f.png)
