### PR TITLE
Local story links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Redirect automatically to project#index after the user authentication, when there is only one team on enrollments
 - **Increase decimal precision from Stories position**
 - Change story controls to react component
+- Links to stories within the same project can be added to a story description.
 
 ## [1.1.3] - 2017-03-30
 ### Changed

--- a/app/assets/javascripts/components/stories/StoryLink.js
+++ b/app/assets/javascripts/components/stories/StoryLink.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import hoverTemplate from 'templates/story_hover.ejs';
+import noteTemplate from 'templates/note.ejs';
+
+const STORY_STATE_ICONS = {
+  unstarted: 'access_time',
+  started:   'check_box_outline_blank',
+  finished:  'check_box',
+  delivered: 'hourglass_empty',
+  rejected:  'close',
+  accepted:  'done'
+};
+
+export default class StoryLink extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    const { story } = this.props;
+    document.getElementById(`story-${story.get('id')}`).scrollIntoView();
+    story && _.each(story.views, view => view.highlight());
+  }
+
+  renderIcon(storyState) {
+    return (
+      <i className={`mi story-link-icon ${storyState}`}>
+        {STORY_STATE_ICONS[storyState]}
+      </i>
+    );
+  }
+
+  render() {
+    const { story } = this.props;
+    const storyState = story.get('state');
+    const id = story.get('id');
+    const popoverContent = hoverTemplate({
+      story: story,
+      noteTemplate: noteTemplate
+    });
+
+    return (
+      <a className={`story-link popover-activate ${storyState}`}
+         data-content={popoverContent}
+         data-original-title={story.get('title')}
+         id={`story-link-${id}`}
+         onClick={this.handleClick}>
+        { `#${id}` }
+        { (storyState !== 'unscheduled') && this.renderIcon(storyState) }
+      </a>
+    );
+  }
+}

--- a/app/assets/javascripts/components/story/StoryDescription.js
+++ b/app/assets/javascripts/components/story/StoryDescription.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import Parser from 'html-react-parser'
+import memoize from 'memoizee';
+
+import StoryLink from 'components/stories/StoryLink';
+
+const editButton = isReadonly =>
+  <input
+    className={!isReadonly && 'edit-description'}
+    disabled={isReadonly}
+    value={I18n.t('edit')}
+    type="button" />
+
+const replaceStoryLink = (domNode, linkedStories) => {
+  if (!domNode.attribs || !domNode.attribs['data-story-id']) return;
+  const id = domNode.attribs['data-story-id'];
+  const story = linkedStories[id];
+  return ( <StoryLink story={story} key={id} /> );
+}
+
+const StoryDescription = ({ description, isReadonly, linkedStories }) => {
+  const isEmpty = (!description || !description.length);
+  description = Parser(description, { replace: domNode =>
+    replaceStoryLink(domNode, linkedStories)
+  });
+
+  return (isEmpty)
+    ? editButton(isReadonly)
+    : <div className='description'>
+        { description }
+      </div>
+}
+
+export default memoize(StoryDescription);

--- a/app/assets/javascripts/views/form_view.js
+++ b/app/assets/javascripts/views/form_view.js
@@ -21,8 +21,8 @@ module.exports = Backbone.View.extend({
   },
 
   textArea: function(name) {
-    var el = this.make('textarea', {name: name, class: 'form-control' }, this.model.get(name));
-    $(el).attr('style', 'height:100px;overflow-y:hidden;');
+    var el = this.make('textarea', {name: name, class: `form-control ${name}-textarea` }, this.model.get(name));
+    $(el).attr('style', 'min-height:100px;');
     $(el).on('input', function () {
       this.style.height = 'auto';
       this.style.height = (this.scrollHeight) + 'px';
@@ -113,21 +113,6 @@ module.exports = Backbone.View.extend({
     }
     var el = this.make('input', attr);
     this.bindElementToAttribute(el, name);
-    return el;
-  },
-
-  submit: function() {
-    var el = this.make('input', {class: "submit", type: "button", value: I18n.t('save')});
-    return el;
-  },
-
-  destroy: function() {
-    var el = this.make('input', {class: "destroy", type: "button", value: I18n.t('delete')});
-    return el;
-  },
-
-  cancel: function() {
-    var el = this.make('input', {class: "cancel", type: "button", value: I18n.t('cancel')});
     return el;
   },
 

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -177,6 +177,17 @@ div.story textarea {
   resize: none;
 }
 
+.form-control.description-textarea {
+  min-height: 100px;
+  max-height: 250px;
+  resize: vertical;
+}
+
+.note-textarea {
+  max-height: 100px;
+  overflow-y: auto;
+}
+
 .story-icons {
   float: left;
 
@@ -219,6 +230,10 @@ div.story-title abbr.initials {
   font-weight: bold;
   margin-left: 0.2em;
   border: none;
+}
+
+.input-group-btn .btn-clipboard-id {
+  padding-top: 6px;
 }
 
 #in_progress div.story,
@@ -271,17 +286,6 @@ div.story-title abbr.initials {
   }
 }
 
-/* Story action buttons */
-.state-actions {
-  float: right;
-  margin-left: 0.2em;
-}
-
-.state-actions form div,
-.state-actions form {
-  display: inline;
-}
-
 /* Iteration markers */
 .iteration {
   padding: 5px 10px;
@@ -294,6 +298,17 @@ div.story-title abbr.initials {
 
 .iteration .points {
   float: right;
+}
+
+/* Story action buttons */
+.state-actions {
+  float: right;
+  margin-left: .2em;
+}
+
+.state-actions form div,
+.state-actions form {
+  display: inline;
 }
 
 .state-actions input {
@@ -359,6 +374,63 @@ a.button {
   color: $sky-blue-3;
   font-size: 84%;
   margin: 0;
+}
+
+.story-link {
+  background: $lightgrey-11;
+  border: 1px solid $lightgrey-13;
+  border-radius: 2px;
+  color: $darkgrey-3;
+  display: inline-block;
+  padding: 1px 3px;
+
+  &:hover, &:focus {
+    background: $lightgrey-2;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  &.accepted {
+    border-color: $chameleon-3;
+  }
+
+  &.rejected {
+    border-color: $darkred;
+  }
+}
+
+.story-link-icon {
+  font-size: 10px;
+  height: 11px;
+  width: 11px;
+  text-align: center;
+  vertical-align: middle;
+  margin-left: 2px;
+
+  &.unstarted {
+    color: $darkgrey-5;
+  }
+
+  &.started  {
+    color: $blue-4;
+    color: $chameleon-3;
+  }
+
+  &.finished {
+    color: $chameleon-3;
+  }
+
+  &.delivered {
+    color: $blue-4;
+  }
+
+  &.accepted {
+    color: $chameleon-3;
+  }
+
+  &.rejected {
+    color: $darkred;
+  }
 }
 
 // Popover Overrides

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cloudinary_js": "^2.1.2",
     "ejs-compiled-loader": "^2.1.1",
     "gritter": "^1.7.4",
+    "html-react-parser": "^0.3.3",
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz",
     "jquery": "^3.1.0",
     "jquery-ui-dist": "^1.12.0",
@@ -26,6 +27,7 @@
     "jquery.caret": "^0.3.1",
     "jquery.scrollto": "^2.1.2",
     "js-cookie": "^2.1.3",
+    "memoizee": "^0.4.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "rewire": "^2.5.2",
@@ -56,4 +58,3 @@
     "sinon": "^1.17.5"
   }
 }
-

--- a/spec/features/stories_spec.rb
+++ b/spec/features/stories_spec.rb
@@ -47,6 +47,45 @@ describe "Stories" do
 
   end
 
+  describe "story links" do
+
+    let!(:story) { create(:story, title: "Story", project: project, requested_by: user)}
+    let!(:target_story) { create(:story, state: 'unscheduled', project: project, requested_by: user)}
+
+    before do
+      story.description = "Story ##{target_story.id}"
+      story.save!
+    end
+
+    it "unscheduled story link", js: true do
+      visit project_path(project)
+      wait_spinner
+      wait_page_load
+
+      find("#story-#{story.id}").click
+      expect(find("#story-#{story.id}").find("#story-link-#{target_story.id}"))
+        .to have_content("##{target_story.id}")
+    end
+
+    ['unstarted', 'started', 'finished', 'delivered', 'accepted', 'rejected'].each do |state|
+      it "#{state} story link", js: true do
+        visit project_path(project)
+        wait_spinner
+        wait_page_load
+
+        find("#story-#{target_story.id}").click
+        within("#story-#{target_story.id}") do
+          find('select[name="state"]').find("option[value='#{state}']").select_option
+          click_on 'Save'
+        end
+
+        find("#story-#{story.id}").click
+        expect(page).to have_css(".story-link-icon.#{state}")
+      end
+    end
+
+  end
+
   describe "delete a story" do
 
     let(:story) {

--- a/spec/javascripts/components/stories/story_link_spec.js
+++ b/spec/javascripts/components/stories/story_link_spec.js
@@ -1,0 +1,67 @@
+import jasmineEnzyme from 'jasmine-enzyme';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import StoryLink from 'components/stories/StoryLink';
+
+import Story from 'models/story.js';
+
+const story = {
+  title: 'Story 2',
+  created_at: sinon.stub(),
+  get: sinon.stub(),
+  humanAttributeName: sinon.stub().returns('Description'),
+  escape: sinon.stub().returns('description'),
+  hasNotes: sinon.stub().returns(false),
+  views: [{highlight: sinon.stub()}]
+};
+
+story.get.withArgs('id').returns('2');
+story.get.withArgs('requested_by_name').returns('Test');
+story.get.withArgs('state').returns('unscheduled');
+story.get.withArgs('story_type').returns('feature');
+
+describe('<StoryLink />', function() {
+
+  beforeEach(function() {
+    jasmineEnzyme();
+    sinon.stub(I18n, 't');
+    sinon.stub(window.md, 'makeHtml');
+    sinon.stub(document, 'getElementById');
+    document.getElementById.returns({scrollIntoView: sinon.stub()});
+  });
+
+  afterEach(function() {
+    I18n.t.restore();
+    window.md.makeHtml.restore();
+    document.getElementById.restore();
+  });
+
+  it("should have his id as content", function() {
+    const wrapper = shallow( <StoryLink story={story} /> );
+    expect(wrapper.find('.story-link')).toHaveText('#2');
+  });
+
+  it("should highlight on click", function() {
+    const wrapper = shallow( <StoryLink story={story} /> );
+    wrapper.find('.story-link').simulate('click');
+    expect(story.views[0].highlight).toHaveBeenCalled();
+  });
+
+  describe(".story-link-icon", function() {
+
+    it("should not exist when story's state is unscheduled", function() {
+      const wrapper = shallow( <StoryLink story={story} /> );
+      expect(wrapper.find('.story-link-icon').length).toBe(0);
+    });
+
+    it("should have a material icon when state is not unscheduled", function() {
+      story.get.withArgs('state').returns('accepted');
+      const wrapper = shallow( <StoryLink story={story} /> );
+      console.log(wrapper.find('.story-link-icon').text());
+      expect(wrapper.find('.story-link-icon')).toHaveText('done');
+    });
+
+  });
+
+});

--- a/spec/javascripts/components/story/story_description_spec.js
+++ b/spec/javascripts/components/story/story_description_spec.js
@@ -1,0 +1,37 @@
+import jasmineEnzyme from 'jasmine-enzyme';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import StoryDescription from 'components/story/StoryDescription';
+import StoryLink from 'components/stories/StoryLink';
+
+describe('<StoryDescription />', function() {
+
+  beforeEach(function() {
+    jasmineEnzyme();
+
+    this.story = {id: 5, description: 'Description'};
+  });
+
+  it("should ignore when there are no valid ids", function() {
+    const wrapper = shallow(
+      <StoryDescription
+        linkedStories={{}}
+        isReadonly={false}
+        description={this.story.description} />
+    );
+    expect(wrapper.find('.description')).toHaveText('Description');
+  });
+
+  it("should turn a valid id into a StoryLink", function() {
+    const linkedStory = {id: 9, get: sinon.stub().returns('unscheduled')};
+    const wrapper = shallow(
+      <StoryDescription
+        linkedStories={{'9': linkedStory}}
+        isReadonly={false}
+        description={'Description <a data-story-id="9"></a>'} />
+    );
+    expect(wrapper.find(StoryLink)).toHaveProp('story', linkedStory);
+  });
+
+});

--- a/spec/javascripts/views/story_view_spec.js
+++ b/spec/javascripts/views/story_view_spec.js
@@ -484,7 +484,7 @@ describe('StoryView', function() {
       this.view.canEdit = sinon.stub().returns(true)
       this.view.render();
       expect(this.view.$('textarea[name="description"]').length).toEqual(1);
-      expect(this.view.$('div.description').length).toEqual(0);
+      expect(this.view.$('div.description-wrapper').length).toEqual(0);
       expect(this.view.$('input.edit-description').length).toEqual(0);
     });
 
@@ -492,13 +492,14 @@ describe('StoryView', function() {
       this.view.model.isNew = sinon.stub().returns(false);
       this.view.render();
       expect(this.view.$('textarea[name="description"]').length).toEqual(0);
-      expect(this.view.$('div.description').length).toEqual(1);
-      expect(this.view.$('input.edit-description').length).toEqual(1);
+      expect(this.view.$('div.description-wrapper').length).toEqual(1);
+      expect(this.view.$('.edit-description').length).toEqual(1);
     });
 
     it('is a text area after .edit-description is clicked', function() {
+      const ev = {target: this.view.$('div.description-wrapper')[0]}
       this.view.model.isNew = sinon.stub().returns(false);
-      this.view.editDescription();
+      this.view.editDescription(ev);
       expect(this.view.model.get('editingDescription')).toBeTruthy();
     });
 


### PR DESCRIPTION
Stage 1 of #81 

Stories in the same Project can now be referenced on another story's
description. A new parser was added on the StoryView to intercept and
turn '#<story_id>' into links which would later turn into StoryLinkViews
providing the current state of the story.


![file](https://cloud.githubusercontent.com/assets/5242693/24671779/218e5c1c-1949-11e7-8308-0922ecb78e79.gif)

**New icons look**
![story-links](https://cloud.githubusercontent.com/assets/5242693/25351660/b66e16c2-28ff-11e7-9e3d-2f7552a18885.png)
