### PR TITLE
Increase decimal precision from Stories position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Redirect automatically to project#index after the user authentication, when there is only one team on enrollments
+- Increase decimal precision from Stories position
 
 ## [1.1.3] - 2017-03-30
 ### Changed

--- a/db/migrate/20170407114148_increase_position_decimal_precision_to_stories.rb
+++ b/db/migrate/20170407114148_increase_position_decimal_precision_to_stories.rb
@@ -1,0 +1,5 @@
+class IncreasePositionDecimalPrecisionToStories < ActiveRecord::Migration
+  def change
+    change_column :stories, :position, :decimal, precision: 25, scale: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119174958) do
+ActiveRecord::Schema.define(version: 20170407114148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 20170119174958) do
     t.integer  "stories_count",                   default: 0
     t.integer  "memberships_count",               default: 0
     t.datetime "archived_at"
-    t.boolean  "disallow_join",                   default: true,       null: false
+    t.boolean  "disallow_join",                   default: true,        null: false
   end
 
   add_index "projects", ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
@@ -176,21 +176,21 @@ ActiveRecord::Schema.define(version: 20170119174958) do
     t.string   "title",             limit: 255
     t.text     "description"
     t.integer  "estimate"
-    t.string   "story_type",        limit: 255, default: "feature"
-    t.string   "state",             limit: 255, default: "unstarted"
+    t.string   "story_type",        limit: 255,                           default: "feature"
+    t.string   "state",             limit: 255,                           default: "unstarted"
     t.datetime "accepted_at"
     t.integer  "requested_by_id"
     t.integer  "owned_by_id"
     t.integer  "project_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.decimal  "position"
+    t.decimal  "position",                      precision: 25, scale: 20
     t.string   "labels",            limit: 255
     t.string   "requested_by_name", limit: 255
     t.string   "owned_by_name",     limit: 255
     t.string   "owned_by_initials", limit: 255
     t.datetime "started_at"
-    t.float    "cycle_time",                    default: 0.0
+    t.float    "cycle_time",                                              default: 0.0
   end
 
   create_table "tasks", force: :cascade do |t|


### PR DESCRIPTION
This PR fixes https://github.com/Codeminer42/cm42-central/issues/144
The decimal precision from stories position wasn't enough for some positions(13 numbers after the decimal point).

ex: `12.62582043025265` was rounded to `12.6258204302527`