### PR TITLE
Some fixes for DatabaseCleaner and Travis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Remove the API module used in `using` params into Project Entity
+- Clean up DatabaseCleaner config
 
 ## [1.3.0] - 2017-04-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Remove the API module used in `using` params into Project Entity
 
 ## [1.3.0] - 2017-04-25
 ### Added

--- a/app/api/entities/project.rb
+++ b/app/api/entities/project.rb
@@ -8,8 +8,8 @@ class Entities::Project < Entities::BaseEntity
   expose :default_velocity
   expose :velocity, if: { type: :full }
   expose :volatility, if: { type: :full }
-  expose :teams, using: API::Entities::Team
-  expose :integrations, using: API::Entities::Integration, if: { type: :full } 
+  expose :teams, using: Entities::Team
+  expose :integrations, using: Entities::Integration, if: { type: :full }
 
   with_options(format_with: :iso_timestamp) do
     expose :created_at, if: lambda { |project, _| project.created_at.present? }

--- a/spec/features/keycut_spec.rb
+++ b/spec/features/keycut_spec.rb
@@ -1,12 +1,8 @@
 require 'feature_helper'
 
 describe "Keycuts" do
-
-  self.use_transactional_fixtures = false
-
   before(:each) do
     ActionController::Base.allow_forgery_protection = false
-    DatabaseCleaner.clean
     sign_in user
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  # config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -59,22 +59,4 @@ RSpec.configure do |config|
 
   config.include Devise::TestHelpers,           type: :controller
   config.include IntegrationHelpers,            type: :feature
-
-  # Turn this off in all request specs
-  module DisableTransactionalFixtures
-    def self.included(base)
-      base.use_transactional_fixtures = false
-      base.after(:each) do |example|
-        while true
-          begin
-            DatabaseCleaner.clean
-            break
-          rescue Exception => e
-            sleep 2
-          end
-        end
-      end
-    end
-  end
-  config.include DisableTransactionalFixtures,  type: :feature
 end

--- a/spec/support/cleaner.rb
+++ b/spec/support/cleaner.rb
@@ -1,10 +1,14 @@
 RSpec.configure do |config|
-  config.before(:suite) { DatabaseCleaner.clean_with(:truncation) }
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
 
   config.before(:each) do |example|
     DatabaseCleaner.strategy = example.metadata[:js] ? :deletion : :transaction
     DatabaseCleaner.start
   end
 
-  config.after(:each) { DatabaseCleaner.clean }
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
 end


### PR DESCRIPTION
This PRs do some fixes as:

- Remove the API module used in `using` params into Project Entity
- Clean up DatabaseCleaner config