### PR TITLE
Added slack integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 ### Added
 - tag group form
 - Added First time tour.
+- Slack Support
 
 ### Changed
-- Story id, location and history input-form-group into a react component 
+- Story id, location and history input-form-group into a react component
 - Story estimate select into a react component
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/Codeminer42/cm42-central-support.git
-  revision: d490666b4fb80be52ff86e86a60f4fff67aa4a81
+  revision: e20ed621257428ebd7180035ca0622fc3445611a
   branch: master
   specs:
     central-support (0.9.3)
@@ -182,7 +182,7 @@ GEM
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
-    enumerize (2.0.1)
+    enumerize (2.1.2)
       activesupport (>= 3.2)
     equalizer (0.0.11)
     erubis (2.7.0)
@@ -279,7 +279,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.10.1)
+    minitest (5.10.2)
     moneta (0.8.0)
     multi_json (1.12.1)
     multi_xml (0.5.5)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Some of the improvements we added since the end of 2015:
   - [x] UI tweaking to make it prettier even without a total redesign
 - [x] Done stories can't be edited, so adding validations and disabling form UIs
 - [x] Added Mattermost basic integration to send story changes to project chat channel
+- [x] Added Slack integration to send story changes to project chat channel
 - [ ] Add APIs for chat slash commands to be able to query projects (ex. /centralstatus project-x)
 - [x] Added basic reports
   - [x] Basic Current Iteration status

--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
       "description": "A Mattermost Hook URL in the format https://yourmattermost.com/hooks/abcdxyz",
       "required": false
     },
+    "INTEGRATION_URI_SLACK": {
+      "description": "A Slack Hook URL in the format https://hooks.slack.com/services/xxxx/xxxx/xxxxxxx",
+      "required": false
+    },
     "LANG": {
       "value": "en_US.UTF-8",
       "required": true

--- a/app/operations/story_operations/state_change_notification.rb
+++ b/app/operations/story_operations/state_change_notification.rb
@@ -33,16 +33,29 @@ module StoryOperations
     def integration_message
       story_link = "#{model.base_uri}#story-#{model.id}"
 
-      case model.state
-      when 'started'
-        "[#{model.project.name}] The story ['#{model.title}'](#{story_link}) has been started."
-      when 'delivered'
-        "[#{model.project.name}] The story ['#{model.title}'](#{story_link}) has been delivered for acceptance."
-      when 'accepted'
-        "[#{model.project.name}] #{model.acting_user.name} ACCEPTED your story ['#{model.title}'](#{story_link})."
-      when 'rejected'
-        "[#{model.project.name}] #{model.acting_user.name} REJECTED your story ['#{model.title}'](#{story_link})."
-      end
+      {slack: [
+          {
+              fallback: "The story '#{model.title}' has been #{model.state}.",
+              color: '#36a64f',
+              title: "#{model.project.name}",
+              title_link: "#{story_link}",
+              text: "The story '#{model.title}' has been #{model.state}.",
+              fields: [
+                  {
+                      title: 'Assigned to',
+                      value: "#{model.owned_by_name}",
+                      short: true
+                  },
+  				        {
+ 					          title: 'Points',
+                     value: "#{model.estimate}",
+                     short: true
+ 				        }
+             ]
+         }
+       ],
+       mattermost: "[#{model.project.name}] The story ['#{model.title}'](#{story_link}) has been #{model.state}."
+     }
     end
   end
 end

--- a/app/views/integrations/_slack.html.erb
+++ b/app/views/integrations/_slack.html.erb
@@ -1,0 +1,13 @@
+<%= form.fields_for :data, OpenStruct.new(form.object.data) do |p| %>
+  <div class="form-group">
+    <%= p.label :private_uri %>
+    <%= p.text_field :private_uri,
+                     value: 'INTEGRATION_URI_SLACK',
+                     class: "form-control auth-form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= p.label :bot_username %>
+    <%= p.text_field :bot_username, class: "form-control auth-form-control" %>
+  </div>
+<% end %>

--- a/app/workers/integration_worker.rb
+++ b/app/workers/integration_worker.rb
@@ -1,11 +1,18 @@
 class IntegrationWorker
   include Sidekiq::Worker
   include Central::Support::MattermostHelper
+  include Central::Support::SlackHelper
 
   def perform(project_id, message)
     project = Project.find(project_id)
     project.integrations.
-      select { |integration| integration.kind == 'mattermost' }.
-      each   { |integration| send_mattermost(integration, message) }
+      each   { |integration|
+        case integration.kind
+        when 'mattermost'
+          send_mattermost(integration, message['mattermost'])
+        when 'slack'
+          send_slack(integration, message['slack'])
+        end
+      }
   end
 end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -36,7 +36,7 @@ describe IntegrationsController do
             get :index, project_id: project.id
             expect(response).to be_success
             expect(assigns[:project]).to eq(project)
-            expect(assigns[:integrations]).to eq([integration])
+            expect(assigns[:integrations][0]).to eq(integration)
           end
         end
 
@@ -45,7 +45,7 @@ describe IntegrationsController do
             get :index, project_id: project.id
             expect(response).to be_success
             expect(assigns[:project]).to eq(project)
-            expect(assigns[:integrations].count).to eq(1)
+            expect(assigns[:integrations].count).to eq(2)
             expect(assigns[:integrations].first.kind).to eq('mattermost')
           end
         end
@@ -143,4 +143,3 @@ describe IntegrationsController do
 
   end
 end
-

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -117,25 +117,109 @@ describe StoryOperations do
       it "sends 'started' email notification" do
         allow(story).to receive_messages(:state => 'started')
         expect(Notifications).to receive(:story_changed).with(story, acting_user) { notifier }
-        expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been started.")
+        expect(IntegrationWorker).to receive(:perform_async).with(project.id, {slack: [
+            {
+                fallback: "The story 'Test Story' has been started.",
+                color: '#36a64f',
+                title: "Test Project",
+                title_link: "http://foo.com/projects/123#story-#{story.id}",
+                text: "The story 'Test Story' has been started.",
+                fields: [
+                    {
+                        title: 'Assigned to',
+                        value: "",
+                        short: true
+                    },
+    				        {
+   					          title: 'Points',
+                       value: "",
+                       short: true
+   				        }
+               ]
+           }
+         ],
+         mattermost:"[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been started."})
         subject.call
       end
       it "sends 'delivered' email notification" do
         allow(story).to receive_messages(:state => 'delivered')
         expect(Notifications).to receive(:story_changed).with(story, acting_user) { notifier }
-        expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been delivered for acceptance.")
+        expect(IntegrationWorker).to receive(:perform_async).with(project.id, {slack: [
+            {
+                fallback: "The story 'Test Story' has been delivered.",
+                color: '#36a64f',
+                title: "Test Project",
+                title_link: "http://foo.com/projects/123#story-#{story.id}",
+                text: "The story 'Test Story' has been delivered.",
+                fields: [
+                    {
+                        title: 'Assigned to',
+                        value: "",
+                        short: true
+                    },
+    				        {
+   					          title: 'Points',
+                       value: "",
+                       short: true
+   				        }
+               ]
+           }
+         ],
+         mattermost:"[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been delivered."})
         subject.call
       end
       it "sends 'accepted' email notification" do
         allow(story).to receive_messages(:state => 'accepted')
         expect(Notifications).to receive(:story_changed).with(story, acting_user) { notifier }
-        expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project]  ACCEPTED your story ['Test Story'](http://foo.com/projects/123#story-#{story.id}).")
+        expect(IntegrationWorker).to receive(:perform_async).with(project.id, {slack: [
+            {
+                fallback: "The story 'Test Story' has been accepted.",
+                color: '#36a64f',
+                title: "Test Project",
+                title_link: "http://foo.com/projects/123#story-#{story.id}",
+                text: "The story 'Test Story' has been accepted.",
+                fields: [
+                    {
+                        title: 'Assigned to',
+                        value: "",
+                        short: true
+                    },
+    				        {
+   					          title: 'Points',
+                       value: "",
+                       short: true
+   				        }
+               ]
+           }
+         ],
+         mattermost:"[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been accepted."})
         subject.call
       end
       it "sends 'rejected' email notification" do
         allow(story).to receive_messages(:state => 'rejected')
         expect(Notifications).to receive(:story_changed).with(story, acting_user) { notifier }
-        expect(IntegrationWorker).to receive(:perform_async).with(project.id, "[Test Project]  REJECTED your story ['Test Story'](http://foo.com/projects/123#story-#{story.id}).")
+        expect(IntegrationWorker).to receive(:perform_async).with(project.id, {slack: [
+            {
+                fallback: "The story 'Test Story' has been rejected.",
+                color: '#36a64f',
+                title: "Test Project",
+                title_link: "http://foo.com/projects/123#story-#{story.id}",
+                text: "The story 'Test Story' has been rejected.",
+                fields: [
+                    {
+                        title: 'Assigned to',
+                        value: "",
+                        short: true
+                    },
+    				        {
+   					          title: 'Points',
+                       value: "",
+                       short: true
+   				        }
+               ]
+           }
+         ],
+         mattermost:"[Test Project] The story ['Test Story'](http://foo.com/projects/123#story-#{story.id}) has been rejected."})
         subject.call
       end
     end

--- a/spec/workers/integration_worker_spec.rb
+++ b/spec/workers/integration_worker_spec.rb
@@ -9,7 +9,7 @@ describe IntegrationWorker do
       integration.data['channel'],
       integration.data['bot_username'],
       "Hello World")
-    IntegrationWorker.new.perform(integration.project_id, "Hello World")
+    IntegrationWorker.new.perform(integration.project_id, {"mattermost"=>"Hello World"})
   end
 
   it "should read URI from ENV" do
@@ -19,6 +19,6 @@ describe IntegrationWorker do
       integration.data['channel'],
       integration.data['bot_username'],
       "Hello World")
-    IntegrationWorker.new.perform(integration.project_id, "Hello World")
+    IntegrationWorker.new.perform(integration.project_id, {"mattermost"=>"Hello World"})
   end
 end


### PR DESCRIPTION
Added slack integration. The messages are sent to the channel with the format below.
<img width="471" alt="screenshot 2017-04-28 17 37 26" src="https://cloud.githubusercontent.com/assets/7603314/25549760/6a566e46-2c39-11e7-9225-5ce0749839b1.png">
If Mattermost and Slack are configured the text will be sent to both services. This depends on a PR in [cm42-central-support](https://github.com/Codeminer42/cm42-central-support/pull/6).