### PR TITLE
Related stories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'rails-i18n'
 gem 'rack-cors', require: 'rack/cors'
 gem "recaptcha", require: "recaptcha/rails"
 gem 'rgb_utils'
+gem 'active_record_union'
 
 gem 'central-support', github: 'Codeminer42/cm42-central-support', branch: 'master', require: 'central/support'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_record_union (1.2.0)
+      activerecord (>= 4.0)
     activeadmin (1.0.0.pre4)
       arbre (~> 1.0, >= 1.0.2)
       bourbon
@@ -182,7 +184,7 @@ GEM
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
-    enumerize (2.0.1)
+    enumerize (2.1.1)
       activesupport (>= 3.2)
     equalizer (0.0.11)
     erubis (2.7.0)
@@ -481,6 +483,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_record_union
   activeadmin (~> 1.0.0.pre4)
   api-pagination
   attachinary

--- a/app/assets/javascripts/components/story/StoryControls.js
+++ b/app/assets/javascripts/components/story/StoryControls.js
@@ -3,9 +3,9 @@ import React from 'react';
 const StoryControls = (props) => {
   return(
     <div className="form-group story-controls">
-      <input className="submit" onClick={props.onClickSave} type="button" value="Save" />
-      <input className="destroy" onClick={props.onClickDelete} type="button" value="Delete" />
-      <input className="cancel" onClick={props.onClickCancel} type="button" value="Cancel" />
+      { !props.related && <input className="submit" onClick={props.onClickSave} type="button" value="Save" /> }
+      { !props.related && <input className="destroy" onClick={props.onClickDelete} type="button" value="Delete" /> }
+      { <input className="cancel" onClick={props.onClickCancel} type="button" value="Cancel" /> }
     </div>
   );
 };

--- a/app/assets/javascripts/models/iteration.js
+++ b/app/assets/javascripts/models/iteration.js
@@ -64,6 +64,10 @@ module.exports = Backbone.Model.extend({
       return false;
     }
 
+    if (story.get('story_type') === 'related') {
+      return false;
+    }
+
     if (this.points() === 0) {
       return true;
     }

--- a/app/assets/javascripts/models/project.js
+++ b/app/assets/javascripts/models/project.js
@@ -315,6 +315,9 @@ module.exports = Backbone.Model.extend({
 
 
     _.each(this.stories.column('#backlog'), function(story) {
+      // Here is selected the stories from the next iteration and if this story
+      // fit in the current iteration it will be added.
+
 
       // The in progress iteration usually needs to be filled with the first
       // few stories from the backlog, unless the points total of the stories
@@ -331,7 +334,6 @@ module.exports = Backbone.Model.extend({
       }
 
       if (!backlogIteration.canTakeStory(story)) {
-
         // Iterations sometimes 'overflow', i.e. an iteration may contain a
         // 5 point story but the project velocity is 1.  In this case, the
         // next iteration that can have a story added is the current + 4.

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -34,8 +34,11 @@ var Story = module.exports = Backbone.Model.extend({
   },
 
   setReadonly: function() {
-    if(this.get('state') === 'accepted' && this.get('accepted_at') !== undefined)
+    if(this.get('state') === 'accepted' &&
+      this.get('accepted_at') !== undefined ||
+      this.get('story_type') === 'related'){
       this.isReadonly = true;
+    }
   },
 
   changeState: function(model, new_value) {
@@ -118,7 +121,6 @@ var Story = module.exports = Backbone.Model.extend({
         }
         break;
     }
-
     this.column = column;
   },
 
@@ -153,20 +155,22 @@ var Story = module.exports = Backbone.Model.extend({
 
   // List available state transitions for this story
   events: function() {
-    switch (this.get('state')) {
-      case 'started':
-        return ["finish"];
-      case 'finished':
-        return ["deliver"];
-      case 'delivered':
-        return ["accept", "reject"];
-      case 'rejected':
-        return ["restart"];
-      case 'accepted':
-        return [];
-      default:
-        return ["start"];
-    }
+      switch (this.get('state')) {
+        case 'started':
+          return ["finish"];
+        case 'finished':
+          return ["deliver"];
+        case 'delivered':
+          return ["accept", "reject"];
+        case 'rejected':
+          return ["restart"];
+        case 'accepted':
+          return [];
+        case 'related':
+          return [];
+        default:
+          return ["start"];
+      }
   },
 
   // State machine transitions

--- a/app/assets/javascripts/views/column_view.js
+++ b/app/assets/javascripts/views/column_view.js
@@ -49,7 +49,7 @@ module.exports = Backbone.View.extend({
   // Adds the sortable behaviour to the column.
   setSortable: function() {
     this.storyColumn().sortable({
-      handle: '.story-title', opacity: 0.6, items: ".story:not(.accepted)",
+      handle: '.story-title', opacity: 0.6, items: ".story:not(.accepted, .related)",
       connectWith: this.data.connect,
       update: function(ev, ui) {
         ui.item.trigger("sortupdate", ev, ui);

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -230,6 +230,7 @@ module.exports = FormView.extend({
     var isEditable              = this.model.get('editing');
     var isSearchResultContainer = this.$el.hasClass('searchResult');
     var clickFromSearchResult   = this.model.get('clickFromSearchResult');
+
     if (_.isUndefined(isEditable))
       isEditable = false;
     if (_.isUndefined(clickFromSearchResult))
@@ -558,11 +559,14 @@ module.exports = FormView.extend({
   },
 
   renderReactComponents: function() {
+    var storyType = this.model.get('story_type');
+
     ReactDOM.render(
       <StoryControls
         onClickSave={this.clickSave}
         onClickDelete={this.clear}
         onClickCancel={this.cancelEdit}
+        related={storyType==='related'}
       />,
       this.$('[data-story-controls]').get(0)
     );
@@ -591,8 +595,10 @@ module.exports = FormView.extend({
   },
 
   setClassName: function() {
+    var story_type = this.model.get('story_type');
+
     var className = [
-      'story', this.model.get('story_type'), this.model.get('state')
+      'story', story_type, this.model.get('state')
     ].join(' ');
     if (this.model.estimable() && !this.model.estimated()) {
       className += ' unestimated';
@@ -600,7 +606,14 @@ module.exports = FormView.extend({
     if (this.isSearchResult) {
       className += ' searchResult';
     }
+
     this.className = this.el.className = className;
+    if(story_type === 'related')
+    {
+      let bg_color = this.model.collection.project.attributes.tag_group_attributes.bg_color;
+      this.$el.css("border-left-color", bg_color);
+    }
+
     return this;
   },
 

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -54,13 +54,6 @@
       text-decoration: none;
     }
 
-    .card-tag {
-      padding: 0 5px;
-      font-size: 9px;
-      border-radius: 5px;
-      text-transform: uppercase;
-    }
-
     .heading-icon {
       z-index: 1;
       position: relative;

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -286,6 +286,17 @@ div.story-title abbr.initials {
   }
 }
 
+.story.related {
+  background-color: $lightyellow-3;
+  border-top-color: $blue-5;
+  border-bottom-color: $blue-3;
+  border-left: 3px solid;
+
+  &:hover {
+    background-color: $lightyellow-4;
+  }
+}
+
 /* Iteration markers */
 .iteration {
   padding: 5px 10px;

--- a/app/assets/stylesheets/_tag-group.scss
+++ b/app/assets/stylesheets/_tag-group.scss
@@ -27,3 +27,19 @@
     flex: 1 5%;
   }
 }
+
+.card-tag {
+  padding: 0 5px;
+  font-size: 9px;
+  border-radius: 5px;
+  text-transform: uppercase;
+  font-weight: bold;
+
+  &-aligned {
+    vertical-align: super;
+  }
+}
+
+.project-tag {
+  padding: 15px 10px 0 0 !important;
+}

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -45,6 +45,8 @@ $orange:        #FF5722;
 
 $lightyellow-1: #F3F3D1;
 $lightyellow-2: #DBDBB0;
+$lightyellow-3: #FFFFCC;
+$lightyellow-4: #FFFF99;
 
 // Tango icon theme pallette
 // http://tango.freedesktop.org/Tango_Icon_Theme_Guidelines

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -6,11 +6,11 @@ class StoriesController < ApplicationController
 
   def index
     @stories = if params[:q]
-                 StorySearch.query(policy_scope(Story), params[:q])
+                 StorySearch.query(project_with_related_stories, params[:q])
                elsif params[:label]
-                 StorySearch.labels(policy_scope(Story), params[:label])
+                 StorySearch.labels(project_with_related_stories, params[:label])
                else
-                 policy_scope(Story).with_dependencies.order('updated_at DESC').tap do |relation|
+                 project_with_related_stories.tap do |relation|
                    relation = relation.limit(ENV['STORIES_CEILING']) if ENV['STORIES_CEILING']
                  end
                end
@@ -97,4 +97,10 @@ class StoriesController < ApplicationController
     @project = policy_scope(Project).friendly.find(params[:project_id])
   end
 
+  def project_with_related_stories
+    @project_with_related_stories ||= ProjectWithRelatedStoriesQuery.call(
+      @project,
+      policy_scope(Story)
+    )
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ActiveRecord::Base
     "default_velocity"
   ].freeze
 
-  JSON_METHODS = ["last_changeset_id", "point_values"].freeze
+  JSON_METHODS = ["last_changeset_id", "point_values", "tag_group_attributes"].freeze
 
   belongs_to :tag_group
 
@@ -26,6 +26,12 @@ class Project < ActiveRecord::Base
   scope :joinable, -> { where(disallow_join: false) }
 
   scope :joinable_except, -> (project_ids) { joinable.where.not(id: project_ids) }
+
+  scope :related_projects, -> (project) { where(tag_group: project.tag_group).where.not(id: project.id) }
+
+  def tag_group_attributes
+    tag_group&.attributes
+  end
 
   def last_changeset_id
     changesets.last && changesets.last.id

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -62,6 +62,8 @@ class Story < ActiveRecord::Base
     !accepted_at_changed? && accepted_at.present?
   end
 
+  scope :with_dependencies, -> { includes(:notes, :tasks, :document_files) }
+
   # Set the project start date to today if the project start date is nil
   # and the state is changing to any state other than 'unstarted' or 'unscheduled'
   def fix_project_start_date

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -2,6 +2,8 @@ class TagGroup < ActiveRecord::Base
   has_many :projects
   belongs_to :team
 
+  before_save :generate_foreground_color
+
   validates :name, presence: true, length: { maximum: 15 }
 
   def bg_color=(value)
@@ -9,6 +11,10 @@ class TagGroup < ActiveRecord::Base
   end
 
   private
+
+  def generate_foreground_color
+    self.foreground_color = RGBUtils::SimpleContrastColorResolver.for(bg_color)
+  end
 
   def convert_bg_color_hash(value)
     RGBUtils::RGB.new(JSON.parse(value)).to_hex rescue value

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -31,15 +31,9 @@ class StoryPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if is_admin?
-        current_project.stories
-      else
-        if is_project_member?
-          current_project.stories
-        else
-          Story.none
-        end
-      end
+      return Story.none unless is_admin? ||  is_project_member?
+
+      current_project.stories
     end
   end
 end

--- a/app/queries/project_with_related_stories_query.rb
+++ b/app/queries/project_with_related_stories_query.rb
@@ -1,0 +1,43 @@
+class ProjectWithRelatedStoriesQuery
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(project, relation = nil)
+    @project = project
+    @relation = (relation || project.stories).select(columns_for_project)
+  end
+
+  def call
+    @relation = relation.union(related_stories) if project.tag_group.present?
+
+    relation.with_dependencies.order('updated_at DESC')
+  end
+
+  private
+
+  attr_reader :project, :relation
+
+  def related_stories
+    related_projects = Project.related_projects(project)
+
+    Story
+      .select(columns_for_related)
+      .where(project: related_projects, story_type: 'release')
+      .where.not(state: 'unscheduled')
+  end
+
+  def columns_for_related
+   columns << "'related' AS story_type"
+  end
+
+  def columns_for_project
+    columns << 'story_type AS story_type'
+  end
+
+  def columns
+   exclude_columns = %w(story_type)
+
+   Story.attribute_names - exclude_columns
+  end
+end

--- a/app/views/projects/_project_header.html.erb
+++ b/app/views/projects/_project_header.html.erb
@@ -1,0 +1,11 @@
+<ul class="nav navbar-nav">
+  <li>
+    <%= link_to @project.name, @project, { class: "project-tag" } %>
+    <% if @project.tag_group.present? %>
+      <small class="card-tag card-tag-aligned"
+      style="background-color: <%= @project.tag_group.bg_color %>; color: <%= @project.tag_group.foreground_color %>">
+      <%= @project.tag_group.name %>
+      </small>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title_bar do %>
-  <ul class="nav navbar-nav">
-    <li>
-      <%= link_to @project.name, @project %>
-    </li>
-  </ul>
+  <%= render partial: "project_header" %>
 <% end %>
 
 <% content_for :navbar do %>

--- a/app/views/projects/import.html.erb
+++ b/app/views/projects/import.html.erb
@@ -1,7 +1,13 @@
 <% content_for :title_bar do %>
 <ul class="nav navbar-nav">
   <li>
-    <%= link_to @project.name, @project %>
+     <%= link_to @project.name, @project, { class: "project-tag" } %>
+      <% unless @project.tag_group.blank? %>
+        <small class="card-tag card-tag-aligned"
+        style="background-color: <%= @project.tag_group.bg_color %>; color: <%= @project.tag_group.foreground_color %>">
+        <%= @project.tag_group.name %>
+        </small>
+      <% end %>
   </li>
 </ul>
 <% end %>

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title_bar do %>
-  <ul class="nav navbar-nav">
-    <li>
-      <%= link_to @project.name, @project %>
-    </li>
-  </ul>
+  <%= render partial: "project_header" %>
 <% end %>
 
 <% content_for :navbar do %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -6,11 +6,7 @@
            locals: { wrapper_class: 'collapsed' } %>
 
 <% content_for :title_bar do %>
-  <ul class="nav navbar-nav">
-    <li>
-      <%= link_to @project.name, @project %>
-    </li>
-  </ul>
+  <%= render partial: "project_header" %>
 
   <p class="navbar-text velocity" id="velocity"></p>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,11 +3,7 @@
 <% end %>
 
 <% content_for :title_bar do %>
-  <ul class="nav navbar-nav">
-    <li>
-      <%= link_to @project.name, @project %>
-    </li>
-  </ul>
+  <%= render partial: "projects/project_header" %>
 <% end %>
 
 <div class="row">

--- a/db/migrate/20170502165153_add_foreground_color_to_tag_group.rb
+++ b/db/migrate/20170502165153_add_foreground_color_to_tag_group.rb
@@ -1,0 +1,5 @@
+class AddForegroundColorToTagGroup < ActiveRecord::Migration
+  def change
+    add_column :tag_groups, :foreground_color, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170407114148) do
+ActiveRecord::Schema.define(version: 20170502165153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,11 +196,12 @@ ActiveRecord::Schema.define(version: 20170407114148) do
 
   create_table "tag_groups", force: :cascade do |t|
     t.integer  "team_id"
-    t.string   "name",        limit: 15
+    t.string   "name",             limit: 15
     t.text     "description"
-    t.string   "bg_color",               default: "#2075F3"
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.string   "bg_color",                    default: "#2075F3"
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.string   "foreground_color"
   end
 
   add_index "tag_groups", ["team_id"], name: "index_tag_groups_on_team_id", using: :btree

--- a/spec/models/tag_group_spec.rb
+++ b/spec/models/tag_group_spec.rb
@@ -7,7 +7,7 @@ describe TagGroup, type: :model do
     context "with valid json" do
       let(:valid_json) { { r: 241, g: 112, b: 19, a: 1 }.to_json }
 
-      subject { described_class.new(bg_color: valid_json) }
+      subject { described_class.create(name: 'tag_group', bg_color: valid_json) }
 
       it "calls the bg_color= method" do
         expect_any_instance_of(TagGroup)
@@ -18,6 +18,8 @@ describe TagGroup, type: :model do
       end
 
       it { expect(subject.bg_color).to eq "#f17013" }
+
+      it { expect(subject.foreground_color).to eq RGBUtils::SimpleContrastColorResolver.for(subject.bg_color) }
     end
 
     context "with invalid json" do

--- a/spec/queries/project_with_related_stories_query_spec.rb
+++ b/spec/queries/project_with_related_stories_query_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ProjectWithRelatedStoriesQuery, type: :queries do
+
+  describe '#call' do
+    let(:project_foo)         { create(:project, name: 'Project foo', tag_group: tag_group) }
+    let(:project_bar)         { create(:project, name: 'Project bar', tag_group: tag_group) }
+    let(:project_baz)         { create(:project, name: 'Project baz') }
+    let(:tag_group)           { create(:tag_group) }
+    let(:release_story_params)    { { title: 'Test Story', story_type: 'release', state: 'started', accepted_at: nil } }
+    let(:normal_story_params)    { { title: 'Test Story', state: 'started', accepted_at: nil } }
+
+    before do
+      3.times do
+        project_foo.stories.create(release_story_params)
+        project_foo.stories.create(normal_story_params)
+
+        project_bar.stories.create(release_story_params)
+        project_bar.stories.create(normal_story_params)
+
+        project_baz.stories.create(release_story_params)
+      end
+    end
+
+    it 'get properly the related stories' do
+      related_stories = project_foo.stories + project_bar.stories.where(story_type: 'release')
+
+      result = ProjectWithRelatedStoriesQuery.call(project_foo)
+      expect(result.size).to eq related_stories.size
+    end
+  end
+end


### PR DESCRIPTION
Display Tag below the project name in settings page

![tag](https://cloud.githubusercontent.com/assets/6487206/25716998/834070ee-30d7-11e7-934c-13b7611d3364.png)

Show related stories
This commit add the functionality to all projects belonging to the same tag group share to each other its release stories.
These stories of type release will be shown in the column done, in progress and backlog.

![related stories](https://cloud.githubusercontent.com/assets/6487206/25717522/16aaa51a-30d9-11e7-9b3a-7b82be62af1c.png)

TO FIX:
All stories are positioned according to it value in the position field.
This causes a misbehavior that makes the stories of a given project display into a different iteration in another project of the same group tag.

PS : 
This PR is dependent from this other https://github.com/Codeminer42/cm42-central-support/pull/4