### PR TITLE
Fix CSS link to throbber.gif when adding a note or a task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Remove the API module used in `using` params into Project Entity
 - Clean up DatabaseCleaner config
+- Display of throbber animated gif when adding a note or a task
 
 ### Added
 - tag group form

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -518,7 +518,7 @@ div.note {
   // The submit button while the server is saving the note.
   input.saving {
     padding-left: 16px;
-    background-image: url('throbber.gif');
+    background-image: image-url('throbber.gif');
     background-repeat: no-repeat;
     background-position: left center;
   }


### PR DESCRIPTION
When adding a note or a task, the throbber.gif was not displayed, as it was requested without the hash, triggering a 404 in a production configuration.

This PR fixes that by ensuring that the hash of the `throbber.gif` is included when the CSS is generated.

![image](https://cloud.githubusercontent.com/assets/96824/25745841/2531a228-31a1-11e7-8f5e-90fc6e6a3e7f.png)