### PR TITLE
Fix typo preventing translation on reports page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Changelog
 
 ## [Unreleased]
-### Fixed
-- Remove the API module used in `using` params into Project Entity
-- Clean up DatabaseCleaner config
-
 ### Added
 - tag group form
 
 ### Fixed
+- Remove the API module used in `using` params into Project Entity
+- Clean up DatabaseCleaner config
 - Admin assignment
+- 'Velocity per member' report title translation
 
 ## [1.3.0] - 2017-04-25
 ### Added

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -35,7 +35,7 @@
             <a href="#velocity-by-iteration" class="nav-link"> <%= t('projects.reports.velocity_by_iteration.title') %></a>
           </li>
           <li class="reports-list-item">
-            <a href="#velocity-by-member" class="nav-link"> <%= t('projects.reports.velocity_by_member.title') %></a>
+            <a href="#velocity-per-member" class="nav-link"> <%= t('projects.reports.velocity_per_member.title') %></a>
           </li>
           <li class="reports-list-item">
             <a href="#bugs-impact" class="nav-link"> <%= t('projects.reports.bugs_impact.title') %></a>
@@ -142,7 +142,7 @@
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <div class="panel panel-default card" id="velocity-by-member">
+    <div class="panel panel-default card" id="velocity-per-member">
       <div class="panel-heading">
         <%= t('projects.reports.velocity_per_member.title') %>
       </div>


### PR DESCRIPTION
Fix #164 

There was a typo preventing an correct translation to 'Velocity per member' report at the Reports page.