### PR TITLE
Fix story activity CSS class name conflicts

### DIFF
--- a/app/assets/javascripts/templates/activity.ejs
+++ b/app/assets/javascripts/templates/activity.ejs
@@ -1,16 +1,16 @@
-<div class="activity">
+<div class="story-activity">
   <div>
     <%= user %> <strong><%= action %></strong>
-    <span class="activity-date"><%= date %></span>
+    <span class="story-activity-date"><%= date %></span>
   </div>
-  <div class="activity-info">
+  <div class="story-activity-info">
     <% _.each(changes, function(change) { %>
-      <div class="activity-changes">
-        <div class="activity-change-attribute">
+      <div class="story-activity-changes">
+        <div class="story-activity-change-attribute">
           <strong><%= change.attribute %></strong>
         </div>
 
-        <div class="activity-change-history">
+        <div class="story-activity-change-history">
           <%= change.oldValue || '---' %>
           <i class="mi md-18">arrow_forward</i>
           <%= change.newValue || '---' %>

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -742,7 +742,7 @@ div#keycut-help {
   max-width: 250px;
 }
 
-.activity {
+.story-activity {
   background-color: $lightgrey-11;
   border-bottom: 1px solid $lightgrey-13;
   border-top: 1px solid $white;


### PR DESCRIPTION
Changes story activity related CSS class names prefix from `.activity` to `.story-activity` in
order to fix a class name conflict with elements from PR #156.

#### Before
![before](https://cloud.githubusercontent.com/assets/5242693/26325340/dd0526d6-3f0c-11e7-94a8-bb16aa70c0c9.png)

#### After
![after](https://cloud.githubusercontent.com/assets/5242693/26325342/dfa86420-3f0c-11e7-87e1-b53161de11f0.png)

