### PR TITLE
[hotfix: 1.4.1] Move babel-preset-airbnb to dependencies in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.4.1] - 2017-05-24
+### Fixed
+- Move "babel-preset-airbnb" outside devDependencies in package.json
+
 ## [1.4.0] - 2017-05-23
 ### Added
 - tag group form
@@ -84,7 +88,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.4.1...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -93,3 +97,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.2.0]: https://github.com/Codeminer42/cm42-central/tree/v1.2.0
 [1.3.0]: https://github.com/Codeminer42/cm42-central/tree/v1.3.0
 [1.4.0]: https://github.com/Codeminer42/cm42-central/tree/v1.4.0
+[1.4.1]: https://github.com/Codeminer42/cm42-central/tree/v1.4.1

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
+    "babel-preset-airbnb": "^2.2.3",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "backbone": "^1.3.3",
@@ -44,7 +45,6 @@
   },
   "devDependencies": {
     "babel-plugin-istanbul": "^3.1.2",
-    "babel-preset-airbnb": "^2.2.3",
     "coveralls": "^2.11.14",
     "enzyme": "^2.7.1",
     "jasmine-core": "^2.5.1",


### PR DESCRIPTION
### Fixed
- Move "babel-preset-airbnb" outside devDependencies in package.json