### PR TITLE
#191 - fix action create in user_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Story History bug when story actions where triggered
 - Ticket not being reassigned to current user when state change to "started"
 - Fix permission users to update others users
+- Fix action create in user_policy
 
 ## [1.4.2] - 2017-05-24
 ### Removed

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -8,7 +8,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    is_admin? || is_himself?
+    is_admin?
   end
 
   def update?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,6 +15,10 @@ class UserPolicy < ApplicationPolicy
     is_himself?
   end
 
+  def destroy?
+    is_admin? || is_himself?
+  end
+
   def is_himself?
     record == current_user
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -47,8 +47,13 @@ describe UserPolicy do
       let(:current_user) { create :user, :with_team }
       subject { UserPolicy.new(pundit_context, current_user) }
 
-      it { should permit(:edit) }
-      it { should permit(:update) }
+      %i[index show edit update destroy].each do |action|
+        it { is_expected.to permit(action) }
+      end
+
+      %i[create new enrollment].each do |action|
+        it { is_expected.not_to permit(action) }
+      end
     end
   end
 


### PR DESCRIPTION
i think don't make sense in action create verify is_himself. 