### PR TITLE
[1.5.0] 2017-06-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.5.0] 2017-06-23
 ### Added
 - Story History is now able to listen for changes on the story
 - Codeclimate file with engines and removed files from analysis
 
 ### Changed
-- story type select to react component
+- Story type select to react component
 - Story state select into react component
 - Story requested_by select to react component
 - Move select components to renderSelects function
@@ -109,7 +111,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.5.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -120,3 +122,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.4.0]: https://github.com/Codeminer42/cm42-central/tree/v1.4.0
 [1.4.1]: https://github.com/Codeminer42/cm42-central/tree/v1.4.1
 [1.4.2]: https://github.com/Codeminer42/cm42-central/tree/v1.4.2
+[1.5.0]: https://github.com/Codeminer42/cm42-central/tree/v1.5.0


### PR DESCRIPTION
### Added
- Story History is now able to listen for changes on the story
- Codeclimate file with engines and removed files from analysis

### Changed
- Story type select to react component
- Story state select into react component
- Story requested_by select to react component
- Move select components to renderSelects function
- Story owned_by select to react component
- Alter route button Manage Members Team and associate user in team
- Story notes into react components
- Story labels to react component

### Fixed
- Story History bug when story actions where triggered
- Ticket not being reassigned to current user when state change to "started"