### PR TITLE
Fix 'stop loading when save' spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixing compatibility of docker-composer with webpack
+- Fixing 'stop loading when save' javascript spec 
 
 ### Changed
 - Story description to react component

--- a/spec/javascripts/components/tasks/task_form_spec.js
+++ b/spec/javascripts/components/tasks/task_form_spec.js
@@ -32,7 +32,7 @@ describe('<TaskForm />', function() {
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it("should stop loading  when save fails", function() {
+  it("should stop loading when save fails", function() {
     const onSubmit = sinon.stub().returns($.Deferred().reject());
     const wrapper = mount(
       <TaskForm
@@ -42,7 +42,7 @@ describe('<TaskForm />', function() {
     );
     wrapper.find('.add-task').simulate('click');
     return $.Deferred().resolve().then(() =>
-      expect(wrapper).toHaveState('loading', false)
+      expect(wrapper.find('.saving')).toHaveLength(0)
     );
   });
 


### PR DESCRIPTION
The spec was trying to access the state of a child component, which it is not possible. So we changed to check if the component has the selector `.saving`

cc: @IgorVieira , @leonardofreitass 