### PR TITLE
Update CHANGELOG to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+## [1.10.0] 2017-09-13
 ### Fixed
 - Allowed params to update project via API
 - Fix central manage login and logout bugs
@@ -160,7 +161,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.10.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -176,3 +177,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.7.0]: https://github.com/Codeminer42/cm42-central/tree/v1.7.0
 [1.8.0]: https://github.com/Codeminer42/cm42-central/tree/v1.8.0
 [1.9.0]: https://github.com/Codeminer42/cm42-central/tree/v1.9.0
+[1.10.0]: https://github.com/Codeminer42/cm42-central/tree/v1.10.0


### PR DESCRIPTION
## [1.10.0] 2017-09-13
### Fixed
- Allowed params to update project via API
- Fix central manage login and logout bugs

### Added
- Don't show projects to guests that he's not member of
- Disallow guests to make changes on projects
