### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.12.0] 2017-09-26
 ### Changed
 - Updated the favicon with the current logo
+- Update Heroku stack
 
 ### Fixed
 - Minor UI glitches on smaller screen resolutions
@@ -181,7 +184,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.12.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -199,3 +202,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.9.0]: https://github.com/Codeminer42/cm42-central/tree/v1.9.0
 [1.10.0]: https://github.com/Codeminer42/cm42-central/tree/v1.10.0
 [1.11.0]: https://github.com/Codeminer42/cm42-central/tree/v1.11.0
+[1.12.0]: https://github.com/Codeminer42/cm42-central/tree/v1.12.0


### PR DESCRIPTION
## [1.12.0] 2017-09-26
### Changed
- Updated the favicon with the current logo
- Update Heroku stack

### Fixed
- Minor UI glitches on smaller screen resolutions