### PR TITLE
Update central-support gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- On projects index, velocity is not always falling to fallback value anymore
+
 ### Added
  Changes to the browser tab as a notification of a change
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Codeminer42/cm42-central-support.git
-  revision: 2de51de4c4a5e5ea7230cca30a1745e254465dde
+  revision: ba735fed7fc9c07b590c4fb138a35f36fc7f42cf
   branch: master
   specs:
     central-support (0.9.3)


### PR DESCRIPTION
Fixes #264 
![image](https://user-images.githubusercontent.com/9031589/30933302-92782372-a3a0-11e7-9845-27098dd0eae0.png)

---
...but also points out another issue on velocity: 
The frontend always use the last 3 iterations with one or more done stories to calculate the velocity. If, for an example, there are no stories on the past iteration and the one before it, it will still use the ones before them until there is 3 iterations with at least one accepted story each (or unless it realizes there are less than 3 iterations). This logic is on `app/assets/javascripts/models/project.js`.

The backend, however, will only look for done iterations on the past month. If there is less than three iterations on the last month, it will not even look for the past stories. This logic is encapsulated on `IterationService` class on central-support gem, and evoked at `ProjectPresenter#velocity`.

It should be noted too, the backend calculates the projects' velocities displayed on `Project index`, while the frontend calculates the velocity on `Project dashboard`.

I did not touch this last issue in particular, part because I am not sure if the frontend or backend behaviour should be kept and part because I personally think that this issue should be addressed in a different PR. I'll open an issue as soon as this gets merged though.