### PR TITLE
Adds the option to drag stories from the search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - On projects index, velocity is not always falling to fallback value anymore
 
 ### Added
- Changes to the browser tab as a notification of a change
+- Changes to the browser tab as a notification of a change
+- User is able to drag and drop stories from search column.
 
 ## [1.12.0] 2017-09-26
 ### Changed

--- a/app/assets/javascripts/templates/project_view.ejs
+++ b/app/assets/javascripts/templates/project_view.ejs
@@ -14,7 +14,7 @@
       <% } %>
       <td style="display: none;" data-column-view="epic" data-hideable="false"></td>
       <td style="display: none;" data-history-view></td>
-      <td style="display: none;" data-column-view="search_results"></td>
+      <td style="display: none;" data-column-view="search_results" data-connect="#chilly_bin,#in_progress,#backlog"></td>
     </tr>
   </tbody>
 </table>

--- a/app/assets/javascripts/templates/story.ejs
+++ b/app/assets/javascripts/templates/story.ejs
@@ -6,14 +6,24 @@
         <span class="estimate estimate-<%= value %> input" data-value="<%= value %>" id="estimate-<%= value %>"></span>
       <% } %>
     <% }); %>
+    <% if (view.isSearchResult) { %>
+      <button id="locate" type="button" class="btn btn-default locate-btn">
+        <i class="mi md-gps-fixed md-14">gps_fixed</i>
+      </button>
+    <% } %>
   </form>
 </div>
 <% } else if (story.events().length > 0) { %>
 <div class="state-actions">
   <form>
-    <% _.each(story.events(),  function(value) { %>
+    <% _.each(story.events(), function(value) { %>
       <input type="button" class="transition <%= value %>" value="<%= I18n.t('story.events.' + value) %>"/>
     <% }); %>
+    <% if (view.isSearchResult) { %>
+      <button id="locate" type="button" class="btn btn-default locate-btn locate">
+        <i class="mi md-gps-fixed md-14">gps_fixed</i>
+      </button>
+    <% } %>
   </form>
 </div>
 <% } %>

--- a/app/assets/javascripts/views/project_search_view.js
+++ b/app/assets/javascripts/views/project_search_view.js
@@ -28,9 +28,13 @@ module.exports = Backbone.View.extend({
   addAll: function() {
     this.$('.loading-spin').addClass('show');
     var that = this;
+    var searchedTerm = this.$el.find('input[type=text]').val();
     that.$ = $;
     that.$('#search_results').html("");
     that.$('.search_results_column').show();
+    that.$('.search_results_column')
+        .find('.toggle-title')
+        .text(`\"${searchedTerm}\"`);
 
     this.addBar('#search_results');
 

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -92,7 +92,8 @@ module.exports = FormView.extend({
     "sortupdate": "sortUpdate",
     "fileuploaddone": "attachmentDone",
     "fileuploadstart": "attachmentStart",
-    "fileuploadfail": "attachmentFail"
+    "fileuploadfail": "attachmentFail",
+    "click #locate": "highlightSearchedStories"
   },
 
   // Triggered whenever a story is dropped to a new position
@@ -257,6 +258,8 @@ module.exports = FormView.extend({
     // Should expand if the click wasn't on one of the buttons.
     if ($(e.target).is('input')) return false
     if ($(e.target).is('.input')) return false
+    if ($(e.target).is('button')) return false
+    if ($(e.target).parent().is('button')) return false
     return true;
   },
 
@@ -335,6 +338,15 @@ module.exports = FormView.extend({
         this.$el.effect("highlight", {}, 3000);
       }
     }
+  },
+
+  highlightSearchedStories: function () {
+    let storyID = `#story-${ this.model.get('id') }`;
+    let storyElement = $(storyID);
+    storyElement.effect("highlight", {}, 3500);
+    storyElement.parent().animate({
+      scrollTop: storyElement.offset().top - 15
+    }, 'slow');
   },
 
   render: function() {
@@ -441,6 +453,7 @@ module.exports = FormView.extend({
       this.$el.html(this.template({story: this.model, view: this}));
       if (isGuest) { this.$el.find('.state-actions').find('.transition').prop('disabled', true) }
     }
+    
     this.hoverBox();
     this.handleBackLoggedRelease();
     return this;

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -54,3 +54,8 @@
     outline: 0;
   }
 }
+
+.locate-btn {
+  @extend input;
+  border-color: #ccc !important;
+}

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -245,7 +245,8 @@ div.story-title abbr.initials {
 
 #in_progress div.story,
 #backlog div.story,
-#chilly_bin div.story {
+#chilly_bin div.story,
+#search_results div.story {
   cursor: move;
 }
 #in_progress div.story.accepted div.story {
@@ -259,9 +260,6 @@ div.story-title abbr.initials {
 }
 
 .estimates {
-  margin-top: 4px;
-  margin-right: 6px;
-
   .estimate {
     margin-left: 10px;
   }

--- a/spec/features/stories_spec.rb
+++ b/spec/features/stories_spec.rb
@@ -222,24 +222,21 @@ describe 'Stories' do
 
     before do
       story
-    end
-
-    it 'finds the story', js: true do
       visit project_path(project)
       wait_spinner
 
-      # should not have any search results by default
-      expect(page).not_to have_css('.searchResult')
-
-      # fill in the search form
       within('#form_search') do
         fill_in 'q', with: 'Search'
       end
-      page.execute_script("$('#form_search').submit()")
+    end
 
+    it 'finds the story', js: true do
+      # should not have any search results by default
+      expect(page).not_to have_css('.searchResult')
+
+      page.execute_script("$('#form_search').submit()")
       # should return at least one story in the result column
       expect(page).to have_css('.searchResult')
-
       within(story_selector(story)) do
         find('.story-title').trigger 'click'
         click_on 'Delete'
@@ -248,6 +245,32 @@ describe 'Stories' do
       # when the story is delete in the results column it should also disappear from other columns
       expect(page).not_to have_css(story_search_result_selector(story))
       expect(page).not_to have_css(story_selector(story))
+    end
+
+    it 'highlights the story on click the locate button', js: true do
+      page.execute_script("$('#form_search').submit()")
+
+      within('#search_results') do
+        find('#locate').trigger 'click'
+      end
+
+      expect(find(story_selector(story))[:style]).to match(/background-color/)
+    end
+
+    it 'drags the story to other columns', js: true do
+      within('#in_progress .story') do
+        find('#estimate-1').trigger 'click'
+        click_on 'start'
+      end
+
+      page.execute_script("$('#form_search').submit()")
+
+      resultStory = find('.searchResult')
+      target = page.first('#chilly_bin')
+      resultStory.drag_to(target)
+
+      expect(page).to_not have_css('.searchResult')
+      expect(find('#chilly_bin')).to have_content('Search for me')
     end
   end
 


### PR DESCRIPTION
### Intent

Changes how the `search results` column works now to add the option so the user can drag stories from there into the other columns. Also add the option to find the actual story on click at the search result story. in accord to the issue #263 moved from #256

![](https://i.gyazo.com/04a8f4a0680a4525aded25d2555c02f9.gif)
---
![](https://i.gyazo.com/919f87730b4e3f0f241b81b8a5c0bd72.gif)