### PR TITLE
Fix folder mapping on docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ run sed -i '/deb-src/d' /etc/apt/sources.list && \
   apt-get update
 
 run apt-get install -y build-essential postgresql-client
-run apt-get install -y redis-server
 run gem install bundler
 RUN curl -sSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" | tar xfJ - -C /usr/local --strip-components=1 && \
   npm install npm -g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       REDISCLOUD_URL: 'redis://redis:6379'
     volumes:
       - .:/app
-      - node_modules:/app/node_modules
+      - ./node_modules:/app/node_modules
     ports:
       - '3000:3000'
     links:
@@ -58,7 +58,7 @@ services:
       - "3808:3808"
     volumes:
       - .:/app
-      - node_modules:/app/node_modules
+      - ./node_modules:/app/node_modules
     command: ruby ./bin/webpack-dev-server
 
 volumes:


### PR DESCRIPTION
- Changed the path to the local node_modules folder. This way, the
mapping between the container and the host will work.
- Removing the redis-server from the Dockerfile, since it's been used in
a separated container.