### PR TITLE
Release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.13.0] 2017-10-11
 ### Fixed
 - On projects index, velocity is not always falling to fallback value anymore
 - Story Attachments not being properly uploaded
@@ -193,7 +195,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.13.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -212,3 +214,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.10.0]: https://github.com/Codeminer42/cm42-central/tree/v1.10.0
 [1.11.0]: https://github.com/Codeminer42/cm42-central/tree/v1.11.0
 [1.12.0]: https://github.com/Codeminer42/cm42-central/tree/v1.12.0
+[1.13.0]: https://github.com/Codeminer42/cm42-central/tree/v1.13.0


### PR DESCRIPTION
## [1.13.0] 2017-10-11
### Fixed
- On projects index, velocity is not always falling to fallback value anymore
- Story Attachments not being properly uploaded
- Update central-support gem version which fixes velocity calculations
- Update velocity calculation on the dashboard

### Added
- Changes to the browser tab as a notification of a change
- User is able to drag and drop stories from search column.