### PR TITLE
Fixes search results column being cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Changes on the style of the estimation form, on a story card.
 
 ### Fixed
-- Show the form to estimate a task without having to open it 
+- Show the form to estimate a task without having to open it
+- Search results column being cleared after dragging a story between columns 
 
 ## [1.13.0] 2017-10-11
 ### Fixed

--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -107,6 +107,7 @@ module.exports = Backbone.View.extend({
     var that = this;
 
     _.each(this.columns, function(column) {
+      if(column.$el.hasClass('search_results_column')) return;
       column.$el.find('.story_column').html("");
     });
 


### PR DESCRIPTION
### Intent
Fix the bug causing the search results to vanish from the search results column after dragging a story from one column to another.
![](https://i.gyazo.com/da25715f1b6106a899c4fb707970fc53.gif)