### PR TITLE
Improvements to docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added adminer service to docker-compose.
+- Added nginx proxy to docker-compose, to enable us to use custom domain names on development.
+
 ### Changed
 - Changes on the style of the estimation form, on a story card.
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,14 @@ Or using docker:
     # Up container
     $ docker-compose up
 
-You should then be able to navigate to `http://localhost:3000/` in a web browser.
+You should then be able to navigate to http://cm42-central.localhost/ in a web browser.
 You can log in with the test username `foo@bar.com`, password `asdfasdf`.
 
+To manage the postgres database, you can access http://adminer.cm42-central.localhost, using the following credentials:
+
+- **server**: postgres
+- **username**: postgres
+- **passowrd**: postgres
 
 Heroku setup
 ------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '2'
 
 services:
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
   postgres:
     image: postgres
     volumes:
@@ -27,11 +34,13 @@ services:
       DB_PASSWORD: ''
       DB_HOST: 'postgres'
       REDISCLOUD_URL: 'redis://redis:6379'
+      VIRTUAL_HOST: 'cm42-central.localhost'
+      VIRTUAL_PORT: 3000
+    ports:
+      - 3000
     volumes:
       - .:/app
       - ./node_modules:/app/node_modules
-    ports:
-      - '3000:3000'
     links:
       - postgres
       - redis
@@ -60,6 +69,13 @@ services:
       - .:/app
       - ./node_modules:/app/node_modules
     command: ruby ./bin/webpack-dev-server
+
+  adminer:
+    image: adminer
+    links:
+      - postgres
+    environment:
+      - VIRTUAL_HOST=adminer.cm42-central.localhost
 
 volumes:
   db:


### PR DESCRIPTION
- Adding nginx-proxy service: with this service setup on the project, we
can use custom domain names while developing locally, avoiding local
ports collision if we already have other app using the port 3000.
- Adding adminer image: added this image to be a quick way to explore
the postgres database, without needing to setup other external tools.