### PR TITLE
Update CHANGELOG to v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.14.0] 2017-10-18
 ### Added
 - Added adminer service to docker-compose.
 - Added nginx proxy to docker-compose, to enable us to use custom domain names on development.
@@ -10,12 +12,10 @@
 - Changes the order which stories appear in the chilly bin column
 
 ### Fixed
-
 - Show the form to estimate a task without having to open it
 - Search results column being cleared after dragging a story between columns
 - Search results wrongly appearing during searches 
 - Updated "central-support" gem to fix the volatility calculation.
-
 
 ## [1.13.0] 2017-10-11
 ### Fixed
@@ -210,7 +210,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.14.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -230,3 +230,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.11.0]: https://github.com/Codeminer42/cm42-central/tree/v1.11.0
 [1.12.0]: https://github.com/Codeminer42/cm42-central/tree/v1.12.0
 [1.13.0]: https://github.com/Codeminer42/cm42-central/tree/v1.13.0
+[1.14.0]: https://github.com/Codeminer42/cm42-central/tree/v1.14.0


### PR DESCRIPTION
## [1.14.0] 2017-10-18
### Added
- Added adminer service to docker-compose.
- Added nginx proxy to docker-compose, to enable us to use custom domain names on development.

### Changed
- Changes on the style of the estimation form, on a story card.
- Changes the order which stories appear in the chilly bin column

### Fixed
- Show the form to estimate a task without having to open it
- Search results column being cleared after dragging a story between columns
- Search results wrongly appearing during searches 
- Updated "central-support" gem to fix the volatility calculation.
