### PR TITLE
Fixes the task's label character escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Changed
 - Updated central-support gem version, so Slack can be used in integrations here now.
 
+### Fixed
+- Tasks labels aren't escaping special characters anymore.
+
 ## [1.14.0] 2017-10-18
 ### Added
 - Added adminer service to docker-compose.

--- a/app/assets/javascripts/components/tasks/Task.js
+++ b/app/assets/javascripts/components/tasks/Task.js
@@ -43,7 +43,7 @@ class Task extends React.Component {
           disabled={disabled}
           onChange={this._handleChange}
           checked={task.get('done')}
-          label={[task.escape('name'), (!disabled && this.renderDelete())]}
+          label={[task.get('name'), (!disabled && this.renderDelete())]}
         />
       </div>
     );


### PR DESCRIPTION
It solves the bug pointed here: https://github.com/Codeminer42/cm42-central/issues/289

Now:
![wmgqlwyttf](https://user-images.githubusercontent.com/402131/32069526-350525d0-ba68-11e7-84bf-811d29b0fd49.gif)
