### PR TITLE
Fixes activities controller to correctly sets current_project to ActivityScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Tasks labels aren't escaping special characters anymore.
+- Activities from a story is now showing correctly to non-admins project members
 
 ## [1.14.0] 2017-10-18
 ### Added

--- a/app/controllers/stories/activities_controller.rb
+++ b/app/controllers/stories/activities_controller.rb
@@ -1,6 +1,9 @@
 class Stories::ActivitiesController < ApplicationController
   def index
-    @activities = policy_scope(Activity).by_story(params[:story_id])
+    @project = policy_scope(Project).friendly.find(params[:project_id])
+    @story = @project.stories.find(params[:story_id])
+    @activities = policy_scope(Activity).by_story(@story.id)
+
     render json: @activities
   end
 end


### PR DESCRIPTION
There was a bug, which was preventing project members to see a story's activities.