### PR TITLE
Update CHANGELOG to v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.15.0] 2017-10-30
 ### Added
 - Added the option to clone a story.
 
@@ -220,7 +222,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.15.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -241,3 +243,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.12.0]: https://github.com/Codeminer42/cm42-central/tree/v1.12.0
 [1.13.0]: https://github.com/Codeminer42/cm42-central/tree/v1.13.0
 [1.14.0]: https://github.com/Codeminer42/cm42-central/tree/v1.14.0
+[1.15.0]: https://github.com/Codeminer42/cm42-central/tree/v1.15.0


### PR DESCRIPTION
## [1.15.0] 2017-10-30
### Added
- Added the option to clone a story.

### Changed
- Updated central-support gem version, so Slack can be used in integrations here now.
- Updated central-support gem version, to fix story cache_names bug when it was removed

### Fixed
- Tasks labels aren't escaping special characters anymore.
- Activities from a story is now showing correctly to non-admins project members