### PR TITLE
Collapsed iterations

### DIFF
--- a/app/assets/javascripts/components/stories/Iteration.js
+++ b/app/assets/javascripts/components/stories/Iteration.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  iterationNumber: PropTypes.node,
+  iterationStartDate: PropTypes.node,
+  points: PropTypes.node,
+};
+
+const Iteration = ({ number, startDate, points }) => {
+    return (
+      <div>
+        {number} - {startDate}
+        <span className="points">{points}</span>
+      </div>
+    );
+}
+
+Iteration.propTypes = propTypes;
+
+export default Iteration;

--- a/app/assets/javascripts/templates/iteration.ejs
+++ b/app/assets/javascripts/templates/iteration.ejs
@@ -1,1 +1,0 @@
-<%= iteration.get('number') %> - <%= iteration.startDate().toDateString() %><span class="points"><%= view.points() %></span>

--- a/app/assets/javascripts/views/iteration_view.js
+++ b/app/assets/javascripts/views/iteration_view.js
@@ -1,6 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Iteration from 'components/stories/Iteration';
+
 module.exports = Backbone.View.extend({
 
-  template: require('templates/iteration.ejs'),
 
   className: 'iteration',
 
@@ -22,7 +25,15 @@ module.exports = Backbone.View.extend({
   },
 
   render: function() {
-    this.$el.html(this.template({iteration: this.model, view: this}));
+    ReactDOM.render(
+      <Iteration
+        number={this.model.get('number')}
+        startDate={this.model.startDate().toDateString()}
+        points={this.points()}
+      />,
+      this.$el[0]
+    );
+
     return this;
   },
 

--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -87,6 +87,9 @@ module.exports = Backbone.View.extend({
     var view = new StoryView({model: story}).render();
     this.appendViewToColumn(view, column);
     view.setFocus();
+    if (column === '#done') {
+      view.$el.addClass('collapsed-iteration');
+    }
   },
 
   appendViewToColumn: function(view, columnName) {
@@ -125,6 +128,7 @@ module.exports = Backbone.View.extend({
       that.addStory(story);
     });
 
+    this.$('#done div.iteration:last').click();
     this.$loadingSpin.hide();
     this.scrollToStory(window.location.hash || '');
   },

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -484,7 +484,7 @@ module.exports = FormView.extend({
       this.$el.html(this.template({story: this.model, view: this}));
       if (isGuest) { this.$el.find('.state-actions').find('.transition').prop('disabled', true) }
     }
-    
+
     this.hoverBox();
     this.handleBackLoggedRelease();
     return this;

--- a/app/assets/stylesheets/_screen.scss
+++ b/app/assets/stylesheets/_screen.scss
@@ -314,6 +314,10 @@ div.story-title abbr.initials {
   float: right;
 }
 
+.collapsed-iteration {
+  display: none;
+}
+
 /* Story action buttons */
 .state-actions {
   float: right;

--- a/spec/javascripts/views/iteration_view_spec.js
+++ b/spec/javascripts/views/iteration_view_spec.js
@@ -23,20 +23,11 @@ describe('IterationView', function() {
 
   describe("render", function() {
 
-    beforeEach(function() {
-      this.view.template.returns('<p>foo</p>');
-    });
-
-    it("calls the template with the iteration and view as arguments", function() {
-      this.view.render();
-      expect(this.view.template).toHaveBeenCalledWith({
-        iteration: this.iteration, view: this.view
-      });
-    });
-
     it("renders the output of the template into the el", function() {
       this.view.render();
-      expect(this.view.$el.html()).toEqual('<p>foo</p>');
+      expect(this.view.$el.html()).toContain(
+        '<span class="points">999</span>'
+      );
     });
 
   });


### PR DESCRIPTION
#### Intent
Changes the way the iterations are handled in the 'done' column, having them previous iterations load collapsed, with only the current one expanded. Fixes #285 
![](https://i.gyazo.com/9440a7605fd609e01a099c939398b112.gif)
