### PR TITLE
Fix projects controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Add jquery-ui to fit cloudinary-js missing dependency
+- Preload tag_group in projects query on projects controller
 
 ## [1.16.0] 2017-11-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Add jquery-ui to fit cloudinary-js missing dependency
 
 ## [1.16.0] 2017-11-28
 ### Added

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,7 +12,7 @@ class ProjectsController < ApplicationController
   def index
     @projects = {}
 
-    projects_joined = policy_scope(Project)
+    projects_joined = policy_scope(Project).preload(:tag_group)
 
     @projects = {
       joined: serialize_from_collection(projects_joined)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "html-react-parser": "^0.3.3",
     "i18n-js": "https://github.com/fnando/i18n-js/archive/v3.0.0.tar.gz",
     "jquery": "^3.1.0",
+    "jquery-ui-bundle": "^1.12.1",
     "jquery-ui-dist": "^1.12.0",
     "jquery-ujs": "^1.2.1",
     "jquery.caret": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,10 @@ javascript-natural-sort@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
 
+jquery-ui-bundle@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1.tgz#d6be2e4c377494e2378b1cae2920a91d1182d8c4"
+
 jquery-ui-dist@^1.12.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz#5c0815d3cc6f90ff5faaf5b268a6e23b4ca904fa"


### PR DESCRIPTION
### Fixed
- Add jquery-ui to fit cloudinary-js missing dependency
- Preload tag_group in projects query on projects controller