### PR TITLE
Update to 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.16.1] 2018-01-03
 ### Fixed
 - Add jquery-ui to fit cloudinary-js missing dependency
 - Preload tag_group in projects query on projects controller
+- Sort all stories in backlog to keep intended priority 
 
 ## [1.16.0] 2017-11-28
 ### Added
@@ -17,7 +20,6 @@
 ### Fixed
 - Webpack manifest host path set to localhost, so webpack pack file load on Windows is fixed
 - Highlight the searched stories not behaving properly.
-- Stories priority sorting
 
 ## [1.15.0] 2017-10-30
 ### Added
@@ -240,7 +242,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.16.1...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -263,3 +265,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.14.0]: https://github.com/Codeminer42/cm42-central/tree/v1.14.0
 [1.15.0]: https://github.com/Codeminer42/cm42-central/tree/v1.15.0
 [1.16.0]: https://github.com/Codeminer42/cm42-central/tree/v1.16.0
+[1.16.1]: https://github.com/Codeminer42/cm42-central/tree/v1.16.1


### PR DESCRIPTION
## [1.16.1] 2018-01-03
### Fixed
- Add jquery-ui to fit cloudinary-js missing dependency
- Preload tag_group in projects query on projects controller
- Sort all stories in backlog to keep intended priority 