### PR TITLE
Update CHANGELOG to v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+## [1.17.0] 2018-01-23
 ### Fixed
 - Adjusted README to use yarn install instead npm install on project setup
 - Remove auto scroll to bottom when adding a story and highlights it instead
@@ -256,7 +257,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.16.1...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v1.17.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -280,3 +281,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.15.0]: https://github.com/Codeminer42/cm42-central/tree/v1.15.0
 [1.16.0]: https://github.com/Codeminer42/cm42-central/tree/v1.16.0
 [1.16.1]: https://github.com/Codeminer42/cm42-central/tree/v1.16.1
+[1.17.0]: https://github.com/Codeminer42/cm42-central/tree/v1.17.0


### PR DESCRIPTION
## [1.17.0] 2018-01-23
### Fixed
- Adjusted README to use yarn install instead npm install on project setup
- Remove auto scroll to bottom when adding a story and highlights it instead
- Fix a bug in stories movement, now this action doesn't select the stories texts

### Added
- Update attachinary options before it gets invalid.

### Changed
- Moved the story estimate buttons to a react component.