### PR TITLE
Altered form to import a file, because conflit js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 - Moved the story estimate buttons to a react component.
+- Change in import project, switch button attachinary_file_field to file_field
 
 ## [1.16.1] 2018-01-03
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Once you have these:
      - sudo yum install memcached
     $ Debian/Ubuntu
      - sudo apt-get install memcached
+    $ MacOS
+     - brew install memcached
     $ Option memcached 
      - sudo /etc/init.d/memcached start
      - sudo /etc/init.d/memcached stop

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ Once you have these:
     $ bundle install
     $ yarn install
 
+    # If you want working with import option, have to activated the option memcached
+    $ CentOS 6.4
+     - sudo yum install memcached
+    $ Debian/Ubuntu
+     - sudo apt-get install memcached
+    $ Option memcached 
+     - sudo /etc/init.d/memcached start
+     - sudo /etc/init.d/memcached stop
+     - sudo /etc/init.d/memcached restart
+    
     # Set up the development database
     $ bundle exec rake fulcrum:setup db:setup
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -152,7 +152,7 @@ class ProjectsController < ApplicationController
 
   # CSV import
   def import_upload
-    if params[:project][:import].blank?
+    if params[:project].blank?
       flash[:alert] = I18n.t('projects.uploads.select_file')
     else
       session[:import_job] = { id: ImportWorker.new_job_id, created_at: Time.current }

--- a/app/views/projects/import.html.erb
+++ b/app/views/projects/import.html.erb
@@ -44,7 +44,7 @@
 
           <%= form_for [:import_upload, @project], html: { class: "form-horizontal import-stories-form" } do |f| %>
             <div class="field select">
-              <%= f.attachinary_file_field :import %>
+              <%= f.file_field :import %>
             </div>
             <div class="field submit">
               <%= f.submit t('import'), class: 'btn btn-default btn-primary btn-form' %>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -331,7 +331,7 @@ describe ProjectsController do
         describe '#import_upload' do
           context 'when csv file is missing' do
             specify do
-              put :import_upload, id: project.id, project: {}
+              put :import_upload, id: project.id
               expect(response).to redirect_to(import_project_path(project))
               expect(flash[:alert])
                 .to eq('You must select a CSV file to import its stories to the project.')

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -331,7 +331,7 @@ describe ProjectsController do
         describe '#import_upload' do
           context 'when csv file is missing' do
             specify do
-              put :import_upload, id: project.id, project: { import: '' }
+              put :import_upload, id: project.id, project: {}
               expect(response).to redirect_to(import_project_path(project))
               expect(flash[:alert])
                 .to eq('You must select a CSV file to import its stories to the project.')


### PR DESCRIPTION
 1. Changes
   - Change field to import from attachinary_file_field to file_field

1. Why
  - The JS fileupload have some conflit, or loading in wrong place, and this way the name from archive that the user do a upload dont appear, it is one way that can do this solution.
