### PR TITLE
Fix freeze screen when save story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 ### Fixed
 - Fixing compatibility of docker-composer with webpack
 - Fixing 'stop loading when save' javascript spec
+- Fixing freeze from screen when create a new story
 
 ## [1.5.0] 2017-06-23
 ### Added

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -108,9 +108,9 @@ var Story = module.exports = Backbone.Model.extend({
 
   saveSorting: function() {
     this.save();
-    this.collection.saveSorting(this.column); 
+    this.collection.saveSorting(this.column);
   },
-  
+
   setColumn: function() {
 
     var column = '#in_progress';
@@ -323,7 +323,7 @@ var Story = module.exports = Backbone.Model.extend({
       if(documents && documents.length > 0 && documents.val()) {
         model.set('documents', JSON.parse(documents.val()));
       } else {
-        model.set('documents', [{}]);
+        model.set('documents', []);
       }
     } else {
       documents = model.get('documents');


### PR DESCRIPTION
Why this PR?
- When you tried create a story, and you failed, the first failed you see the error, but if you click em create again, so your screen become freeze, and refresh the page is necessary.

