### PR TITLE
Front-end performance issues

### DIFF
--- a/app/assets/javascripts/collections/story_collection.js
+++ b/app/assets/javascripts/collections/story_collection.js
@@ -19,6 +19,7 @@ module.exports = Backbone.Collection.extend({
   },
 
   saveSorting: function(columnName) {
+    var collection = this;
     var column = this;
     if(columnName) {
       column = this.column(columnName);
@@ -28,10 +29,13 @@ module.exports = Backbone.Collection.extend({
         return model.id;
       }
     );
-    Backbone.ajax({
+
+    collection.sorting = Backbone.ajax({
       method: 'PUT',
       url: this.url + '/sort',
       data: { ordered_ids: orderedIds }
+    }).always( function() {
+      collection.sorting = null;
     });
   },
 

--- a/app/assets/javascripts/components/jquery_wrappers/AtWhoInput.js
+++ b/app/assets/javascripts/components/jquery_wrappers/AtWhoInput.js
@@ -10,11 +10,19 @@ class AtWhoInput extends React.Component {
     this.loadAtWho();
   }
 
+  componentWillUnmount() {
+    this.unloadAtWho();
+  }
+
   loadAtWho() {
     $(this.textarea).atwho({
       at: "@",
       data: this.props.usernames
     }).on('inserted.atwho', this.props.onChange);
+  }
+
+  unloadAtWho() {
+    $(this.textarea).atwho('destroy');
   }
 
   render() {

--- a/app/assets/javascripts/components/jquery_wrappers/TaggedInput.js
+++ b/app/assets/javascripts/components/jquery_wrappers/TaggedInput.js
@@ -10,16 +10,25 @@ class TaggedInput extends React.Component {
     this.loadTagit();
   }
 
+  componentWillUnmount() {
+    this.unloadTagit();
+  }
+
   loadTagit() {
     $(this.input).tagit(
       this.tagitProperties()
     ).on('change', this.props.onChange);
   }
 
+  unloadTagit() {
+    $(this.input).tagit('removeAll');
+  }
+
   tagitProperties() {
     return {
       availableTags: this.props.availableLabels,
       readOnly: this.props.disabled,
+      singleField: true,
     };
   }
 

--- a/app/assets/javascripts/mixins/shared_model_methods.js
+++ b/app/assets/javascripts/mixins/shared_model_methods.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   hasErrors: function() {
-    return (!_.isUndefined(this.get('errors')));
+    return (!_.isEmpty(this.get('errors')));
   },
 
   errorsOn: function(field) {

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -83,7 +83,7 @@ var Story = module.exports = Backbone.Model.extend({
     }
     var difference = (afterPosition - before.position()) / 2;
     var newPosition = difference + before.position();
-    this.set({position: newPosition});
+    this.set({position: newPosition}, {silent: true});
     this.saveSorting();
     return this;
   },
@@ -100,15 +100,22 @@ var Story = module.exports = Backbone.Model.extend({
     var difference = (after.position() - beforePosition) / 2;
     var newPosition = difference + beforePosition;
 
-    this.set({position: newPosition});
+    this.set({position: newPosition}, {silent: true});
     this.collection.sort({silent: true});
     this.saveSorting();
     return this;
   },
 
   saveSorting: function() {
-    this.save();
-    this.collection.saveSorting(this.column);
+    var that = this;
+    that.save();
+    if(that.collection.sorting) {
+      that.collection.sorting.done(function() {
+        that.collection.saveSorting(that.column);
+      })
+    } else {
+      that.collection.saveSorting(that.column);
+    }
   },
 
   setColumn: function() {

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -283,6 +283,7 @@ module.exports = FormView.extend({
   },
 
   cancelEdit: function() {
+    this.clearAtWhoContainer();
     this.model.set({editing: false});
 
     // If the model was edited, but the edits were deemed invalid by the
@@ -320,6 +321,7 @@ module.exports = FormView.extend({
         that.model.set({ editing: editMode });
         that.toggleControlButtons(false);
         that.highlightStory();
+        that.clearAtWhoContainer();
       },
       error: function(model, response) {
         var json = $.parseJSON(response.responseText);
@@ -329,16 +331,18 @@ module.exports = FormView.extend({
           title: I18n.t("save error"),
           text: model.errorMessages()
         });
-
         that.enableForm();
+        that.clearAtWhoContainer();
       }
     });
   },
 
   // Delete the story and remove it's view element
   clear: function() {
-    if (confirm("Are you sure you want to destroy this story?"))
+    if (confirm("Are you sure you want to destroy this story?")) {
+      this.clearAtWhoContainer();
       this.model.clear();
+    }
   },
 
   editDescription: function(ev) {
@@ -847,6 +851,7 @@ module.exports = FormView.extend({
   },
 
   handleTaskDelete: function(task) {
+    this.clearAtWhoContainer();
     task.destroy();
     this.renderTasks();
   },
@@ -1116,5 +1121,10 @@ module.exports = FormView.extend({
 
   showHistory: function() {
     this.model.showHistory();
+  },
+
+  clearAtWhoContainer: function() {
+    // to destroy the atwho container
+    $('.atwho-container').remove();
   },
 });

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -130,9 +130,9 @@ module.exports = FormView.extend({
     // Set the story state if drop column is chilly_bin or backlog
     var column = target.parent().attr('id');
     if (column === 'backlog' || (column === 'in_progress' && this.model.get('state') === 'unscheduled')) {
-      this.model.set({state: 'unstarted'});
+      this.model.set({state: 'unstarted'}, {silent: true});
     } else if (column === 'chilly_bin') {
-      this.model.set({state: 'unscheduled'});
+      this.model.set({state: 'unscheduled'}, {silent: true});
       [previous_story_id, next_story_id] = [next_story_id, previous_story_id];
     }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,7 @@
   <%= csrf_meta_tag %>
   <%= favicon_link_tag "favicon.ico" %>
   <%= stylesheet_link_tag :application %>
-  <%= javascript_include_tag "https://www.authy.com/form.authy.min.js" %>
-  <%= stylesheet_link_tag "https://www.authy.com/form.authy.min.css" %>
+  <%= stylesheet_link_tag "//cdnjs.cloudflare.com/ajax/libs/authy-form-helpers/2.3/form.authy.min.css" %>
   <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Noto+Sans:400,700" %>
 </head>
 <body class='<%= "board" if @layout_settings[:fluid] %>' data-page='<%= "#{params[:controller]}.#{params[:action]}" %>'>
@@ -118,6 +117,7 @@
   </div>
 </div>
 
+<%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/authy-form-helpers/2.3/form.authy.min.js" %>
 <%= javascript_pack_tag 'app' %>
 <%= javascript_include_tag 'i18n/translations' %>
 <%= javascript_include_tag :attachinary %>


### PR DESCRIPTION
This PR attempts to reduce user interface response delay, by fixing backbone model views creation, clearing the auto complete libs containers created for utility ([atwho](https://github.com/ichord/At.js/) and [tagit](https://github.com/aehlke/tag-it) ), organizing imports and more. It follows the issue #333 report and discussion.

Changes include:

- Limit the new story creation by one at a time.
- Use cdn for js imports.
- Apply the delete previous story view before adding new one approach. 

Previously, the way backbone models event handlers were made yielded multiple StoryViews for a single story. That situation occurred when all stories were fetch, on store sorting and story column change.

Any suggestions/recommendations are very welcome. Such delete-create way may not be the most accurate.