### PR TITLE
Don't convert empty arrays to nil

### DIFF
--- a/config/initializers/monkey-patchs.rb
+++ b/config/initializers/monkey-patchs.rb
@@ -1,0 +1,1 @@
+require 'actionpack_extensions/action_dispatch/request/utils'

--- a/lib/actionpack_extensions/action_dispatch/request/utils.rb
+++ b/lib/actionpack_extensions/action_dispatch/request/utils.rb
@@ -1,0 +1,27 @@
+module ActionpackExtensions
+  module ActionDispatch
+    module Request
+      module Utils
+        def deep_munge(hash, keys = [])
+          return hash unless perform_deep_munge
+          hash.each do |k, v|
+            keys << k
+            case v
+            when Array
+              v.grep(Hash) { |x| deep_munge(x, keys) }
+              v.compact!
+            when Hash
+              deep_munge(v, keys)
+            end
+            keys.pop
+          end
+          hash
+        end
+      end
+    end
+  end
+end
+
+Rails.configuration.to_prepare do
+  ActionDispatch::Request::Utils.singleton_class.prepend ActionpackExtensions::ActionDispatch::Request::Utils
+end

--- a/lib/actionpack_extensions/action_dispatch/request/utils.rb
+++ b/lib/actionpack_extensions/action_dispatch/request/utils.rb
@@ -24,5 +24,5 @@ end
 
 Rails.configuration.to_prepare do
   ActionDispatch::Request::Utils.singleton_class
-    .prepend ActionpackExtensions::ActionDispatch::Request::Utils
+                                .prepend ActionpackExtensions::ActionDispatch::Request::Utils
 end

--- a/lib/actionpack_extensions/action_dispatch/request/utils.rb
+++ b/lib/actionpack_extensions/action_dispatch/request/utils.rb
@@ -23,5 +23,6 @@ module ActionpackExtensions
 end
 
 Rails.configuration.to_prepare do
-  ActionDispatch::Request::Utils.singleton_class.prepend ActionpackExtensions::ActionDispatch::Request::Utils
+  ActionDispatch::Request::Utils.singleton_class
+    .prepend ActionpackExtensions::ActionDispatch::Request::Utils
 end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -90,7 +90,7 @@ describe StoriesController do
       end
     end
 
-    context 'update without losing documents' do
+    context 'update documents' do
       let(:attachments) do
         [
           {
@@ -142,6 +142,13 @@ describe StoriesController do
             end.to change { story.reload; story.documents.count }.by(0)
             expect(response).to be_success
           end
+        end
+
+        it 'should delete all documents (resilient against deep_munge rails/rails#13420)' do
+          expect(story.documents.count).to eq(2)
+          xhr :put, :update, project_id: project.id, id: story.id, story: ActionDispatch::Request::Utils.deep_munge({ documents: [] })
+          story.reload
+          expect(story.documents.count).to eq(0)
         end
       end
     end


### PR DESCRIPTION
	Deep munge was introduced to keep query generation safe. This patch applies
	the behaviour present in Rails 5.0 and 5.1. For a broader discussion see
	rails/rails#13420