### PR TITLE
Fix the load speed of projects after choosing a team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Removed
+- Remove Velocity / Volatility from ProjectCard to optimize performance
 
 ## [1.20.0] 2018-09-14
 ### Added

--- a/app/assets/javascripts/components/projects/ProjectCard.js
+++ b/app/assets/javascripts/components/projects/ProjectCard.js
@@ -97,16 +97,6 @@ export default class ProjectCard extends React.Component {
     if (joined) {
       return(
         <div className="panel-body">
-          <div className="col-md-6 col-xs-6 counter">
-            <span className="counter-description">{ I18n.t('velocity') }</span>
-            <span className="counter-value">{ project.get('velocity') }</span>
-          </div>
-
-          <div className="col-md-6 col-xs-6 counter">
-            <span className="counter-description">{ I18n.t('volatility') }</span>
-            <span className="counter-value">{ project.get('volatility') }</span>
-          </div>
-
           <div className="col-md-12 members">
             <ul className="member-list">
               { this.renderUsersAvatar() }

--- a/app/assets/stylesheets/_members.scss
+++ b/app/assets/stylesheets/_members.scss
@@ -1,7 +1,6 @@
 .members {
   display: table;
   margin: 0 auto;
-  margin-top: 15px;
   text-align: center;
 
   .member-list {

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -13,8 +13,6 @@ class ProjectSerializer
 
   def initialize(attrs = {})
     self.name = attrs.truncate_name
-    self.velocity = attrs.velocity
-    self.volatility = attrs.volatility
     self.slug = attrs.slug
     self.path_to = attrs.path_to
     self.archived_at = attrs.archived_date

--- a/spec/javascripts/components/projects/project_card_spec.js
+++ b/spec/javascripts/components/projects/project_card_spec.js
@@ -147,26 +147,6 @@ describe('<ProjectCard />', () => {
 
     describe('#panelBody', () => {
       describe('not archived', () => {
-        it('should contain velocity information', () => {
-          const wrapper = shallow(<ProjectCard {...defaultProps} />);
-          expect(wrapper.contains(
-            <div className="col-md-6 col-xs-6 counter">
-              <span className="counter-description">{ I18n.t('velocity') }</span>
-              <span className="counter-value">10</span>
-            </div>
-          )).toBe(true);
-        });
-
-        it('should contain volatility information', () => {
-          const wrapper = shallow(<ProjectCard {...defaultProps} />);
-          expect(wrapper.contains(
-            <div className="col-md-6 col-xs-6 counter">
-              <span className="counter-description">{ I18n.t('volatility') }</span>
-              <span className="counter-value">0%</span>
-            </div>
-          )).toBe(true);
-        });
-
         it('should contain users avatar', () => {
           const wrapper = shallow(<ProjectCard {...defaultProps} />);
           expect(wrapper.contains(

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -12,14 +12,6 @@ describe ProjectSerializer do
     expect(project.truncate_name).to eq(serialized_project.name)
   end
 
-  it 'should have a velocity that matches' do
-    expect(project.velocity).to eq(serialized_project.velocity)
-  end
-
-  it 'should have a volatility that matches' do
-    expect(project.volatility).to eq(serialized_project.volatility)
-  end
-
   it 'should have a slug that matches' do
     expect(project.slug).to eq(serialized_project.slug)
   end


### PR DESCRIPTION
When taking the `/teams` route, after selecting your team and depending on how many projects you have on that team, the load time was taking too long (more than a minute in some cases), causing a timeout.

This PR intends to accelerate this load considerably by removing the volatility / velocity from the ProjectCard, since there is no real need to have it being shown there and it makes the page load in less than 5s.

## Before

![screen shot 2018-09-24 at 15 51 38](https://user-images.githubusercontent.com/12839214/46086313-31c78700-c17e-11e8-80fd-71b445ee8578.png)

## After

![screen shot 2018-09-24 at 15 51 25](https://user-images.githubusercontent.com/12839214/46086326-37bd6800-c17e-11e8-981b-edf7b7b57841.png)
