### PR TITLE
Group by sprints directly in the store

### DIFF
--- a/app/assets/javascripts/actions/column.js
+++ b/app/assets/javascripts/actions/column.js
@@ -6,9 +6,10 @@ const setStoryChillyBin = payload => ({
   data: payload
 });
 
-const setStoryBacklog = payload => ({
+const setStoryBacklog = (payload, project) => ({
   type: actionTypes.COLUMN_BACKLOG,
-  data: payload
+  data: payload,
+  project: project
 });
 
 const setStoryDone = payload => ({
@@ -21,7 +22,7 @@ export const getColumnType = (story, project) => {
     return setStoryChillyBin(story);
   }
   if (isBacklog(story, project)) {
-    return setStoryBacklog(story);
+    return setStoryBacklog(story, project);
   }
   return setStoryDone(story);
 };

--- a/app/assets/javascripts/components/Columns/ColumnItem.js
+++ b/app/assets/javascripts/components/Columns/ColumnItem.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Stories from "../stories/Stories";
 
 const Column = ({ title, children }) => (
   <div className="Column">

--- a/app/assets/javascripts/components/projects/ProjectBoard.js
+++ b/app/assets/javascripts/components/projects/ProjectBoard.js
@@ -25,7 +25,7 @@ class ProjectBoard extends React.Component {
           ${I18n.t("projects.show.in_progress")}`}>
           <Sprints
             stories={this.props.columns.backlog.stories}
-            project={this.props.project}
+            sprints={this.props.columns.backlog.sprints}
           />
         </Column>
 

--- a/app/assets/javascripts/components/projects/ProjectBoard.js
+++ b/app/assets/javascripts/components/projects/ProjectBoard.js
@@ -24,7 +24,6 @@ class ProjectBoard extends React.Component {
           title={`${I18n.t("projects.show.backlog")} /
           ${I18n.t("projects.show.in_progress")}`}>
           <Sprints
-            stories={this.props.columns.backlog.stories}
             sprints={this.props.columns.backlog.sprints}
           />
         </Column>

--- a/app/assets/javascripts/components/stories/Sprints.js
+++ b/app/assets/javascripts/components/stories/Sprints.js
@@ -30,8 +30,8 @@ const renderSprints = sprints => {
   );
 };
 
-const Sprints = ({ stories, sprints }) => {
-  if (!stories.length) return null;
+const Sprints = ({ sprints }) => {
+  if (!sprints.length) return null;
 
   return <div className="Sprints">{renderSprints(sprints)}</div>;
 };

--- a/app/assets/javascripts/components/stories/Sprints.js
+++ b/app/assets/javascripts/components/stories/Sprints.js
@@ -1,16 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Sprint from "./Sprint";
-import * as Iteration from "models/beta/iteration";
 
 const propTypes = {
   stories: PropTypes.array,
-  project: PropTypes.object
+  project: PropTypes.object,
+  sprints: PropTypes.array,
 };
 
 const defaultProps = {
   stories: [],
-  project: {}
+  project: {},
+  sprints: [],
 };
 
 const renderSprints = sprints => {
@@ -29,14 +30,7 @@ const renderSprints = sprints => {
   );
 };
 
-const Sprints = ({ stories, project }) => {
-  const currentSprintNumber = Iteration.getCurrentIteration(project) || 0;
-  const sprints = Iteration.groupBySprints(
-    stories,
-    project,
-    currentSprintNumber
-  );
-
+const Sprints = ({ stories, sprints }) => {
   if (!stories.length) return null;
 
   return <div className="Sprints">{renderSprints(sprints)}</div>;

--- a/app/assets/javascripts/models/beta/iteration.js
+++ b/app/assets/javascripts/models/beta/iteration.js
@@ -90,8 +90,10 @@ const addStoryToSprint = (project, sprints, index, story) => {
     }
   }
   fillRemainingPoints(
-    sprints, Story.getPoints(story),
-    index, project.defaultVelocity,
+    sprints, 
+    Story.getPoints(story),
+    index, 
+    project.defaultVelocity,
     previousFillerSprintsQuantity
   );
 

--- a/app/assets/javascripts/reducers/columns/backlog.js
+++ b/app/assets/javascripts/reducers/columns/backlog.js
@@ -5,7 +5,8 @@ import _ from "underscore";
 import * as Iteration from "models/beta/iteration";
 
 const initialState = {
-  stories: []
+  stories: [],
+  sprints: [],
 };
 
 const filterByState = state => story => {

--- a/app/assets/javascripts/reducers/columns/backlog.js
+++ b/app/assets/javascripts/reducers/columns/backlog.js
@@ -2,6 +2,7 @@ import actionTypes from "actions/actionTypes";
 import { status } from "libs/beta/constants";
 import * as Story from "models/beta/story";
 import _ from "underscore";
+import * as Iteration from "models/beta/iteration";
 
 const initialState = {
   stories: []
@@ -38,7 +39,7 @@ const orderByState = stories => {
   );
   const unestimatedUnstartedStories = partitionedFeatures[0];
   const estimatedUnstartedStories = partitionedFeatures[1];
-
+  
   return [
     ...acceptedStories,
     ...deliveredStories,
@@ -50,13 +51,24 @@ const orderByState = stories => {
   ];
 };
 
+const groupStoriesInSprints = (stories, project) => {
+  const currentSprintNumber = Iteration.getCurrentIteration(project) || 0;
+
+  return Iteration.groupBySprints(
+    stories,
+    project,
+    currentSprintNumber
+  )
+};
+
 const backlog = (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.COLUMN_BACKLOG:
       const stories = [...state.stories, action.data];
 
       return {
-        stories: orderByState(stories)
+        stories: orderByState(stories),
+        sprints: groupStoriesInSprints(stories, action.project)
       };
     default:
       return state;

--- a/app/assets/javascripts/reducers/columns/backlog.js
+++ b/app/assets/javascripts/reducers/columns/backlog.js
@@ -58,17 +58,17 @@ const groupStoriesInSprints = (stories, project) => {
     stories,
     project,
     currentSprintNumber
-  )
+  );
 };
 
 const backlog = (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.COLUMN_BACKLOG:
       const stories = [...state.stories, action.data];
-
+      const orderedStories = orderByState(stories);
       return {
-        stories: orderByState(stories),
-        sprints: groupStoriesInSprints(stories, action.project)
+        stories: orderedStories,
+        sprints: groupStoriesInSprints(orderedStories, action.project)
       };
     default:
       return state;

--- a/spec/javascripts/components/stories/sprints_spec.js
+++ b/spec/javascripts/components/stories/sprints_spec.js
@@ -66,12 +66,13 @@ describe("<Sprints />", () => {
     expect(wrapper.find("Sprint")).toHaveLength(1);
   });
 
-  describe("when no stories are passed as props", () => {
+  describe("when no sprints are passed as props", () => {
     beforeEach(() => {
       props = createProps();
-      props.stories = [];
+      props.sprints = [];
       wrapper = shallow(<Sprints {...props} />);
     });
+    
     it("does not render any <Sprint> component", () => {
       expect(wrapper.find("Sprint")).toHaveLength(0);
     });

--- a/spec/javascripts/components/stories/sprints_spec.js
+++ b/spec/javascripts/components/stories/sprints_spec.js
@@ -27,7 +27,32 @@ const createProps = () => ({
     startDate: "2018-09-03T16:00:00",
     iterationLength: 1,
     defaultVelocity: 2
-  }
+  },
+  sprints: [
+    {
+      completedPoints: 0,
+      isFiller: false,
+      number: 1,
+      points: 1,
+      remainingPoints: 1,
+      stories: [
+        {
+          id: 1,
+          position: "3",
+          state: "unstarted",
+          estimate: 1,
+          storyType: "feature"
+        },
+        {
+          id: 2,
+          position: "2",
+          state: "unstarted",
+          estimate: 1,
+          storyType: "feature"
+        }
+      ],
+    }
+  ]
 });
 
 describe("<Sprints />", () => {

--- a/spec/javascripts/reducers/column_backlog_spec.js
+++ b/spec/javascripts/reducers/column_backlog_spec.js
@@ -44,20 +44,36 @@ describe('Backlog Column reducer', () => {
           deliveredAt: '2018-08-06T16:36:20.811Z',
           estimate: 1
         }
+      ],
+      sprints: [
+        {
+          completedPoints: 0,
+          isFiller: false,
+          number: 1,
+          points: 1,
+          remainingPoints: 1,
+          stories: [],
+        }
       ]
     }
   }
 
   function createEmptyInitialstate() {
     return {
-      stories: []
+      stories: [],
+      sprints: [],
     }
   }
 
   function createAction(data) {
     return {
       type: actionTypes.COLUMN_BACKLOG,
-      data
+      data,
+      project: {
+        startDate: "2018-09-03T16:00:00",
+        iterationLength: 1,
+        defaultVelocity: 2,
+      },
     }
   }
 

--- a/spec/javascripts/reducers/column_backlog_spec.js
+++ b/spec/javascripts/reducers/column_backlog_spec.js
@@ -45,16 +45,6 @@ describe('Backlog Column reducer', () => {
           estimate: 1
         }
       ],
-      sprints: [
-        {
-          completedPoints: 0,
-          isFiller: false,
-          number: 1,
-          points: 1,
-          remainingPoints: 1,
-          stories: [],
-        }
-      ]
     }
   }
 
@@ -96,7 +86,6 @@ describe('Backlog Column reducer', () => {
 
 
   describe("when there are stories on the initial state", () => {
-
     it("return the new story with the others", () => {
       const newStory = {
         id : 80,
@@ -127,6 +116,58 @@ describe('Backlog Column reducer', () => {
       expect(state.stories[5].state).toEqual('unstarted');
     });
 
+    describe("when stories are grouped by sprints", () => {
+      const stories = [
+        {
+          id: 1,
+          position: '1.0',
+          state: 'unstarted',
+          estimate: 2,
+          storyType: "feature",
+        },
+        {
+          id: 2,
+          position: '2.0',
+          state: 'unstarted',
+          estimate: 2,
+          storyType: "feature",
+        },
+        {
+          id: 3,
+          position: '4.0',
+          state: 'delivered',
+          estimate: 2,
+          storyType: "feature",
+        },
+        {
+          id: 4,
+          position: '4.0',
+          state: 'finished',
+          estimate: 2,
+          storyType: "feature",
+        },
+      ];
+      const action = createAction(stories);
+      let state;
+      
+      beforeEach(() => {
+        state = reducer({ stories: stories, sprints: [] }, action);
+      });
+      
+      it("creates 3 sprints", () => {
+        expect(state.sprints.length).toEqual(3);
+      });
+
+      it("adds 2 stories to current sprint", () => {
+        expect(state.sprints[0].stories.length).toEqual(2);
+      });
+
+      it("stories grouped in current sprint are ordered by state", () => {
+        expect(state.sprints[0].stories[0].state).toEqual('delivered');
+        expect(state.sprints[0].stories[1].state).toEqual('finished');
+      });
+    });
+
     describe("when the story states are the same", () => {
       describe("accepted stories", () => {
         describe("when the acceptedAt of the new story is older then the others", () => {
@@ -146,7 +187,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[0].state).toEqual('accepted');
             expect(state.stories[1].state).toEqual('accepted');
             expect(state.stories[0].id).toEqual(newStory.id);
-
           });
         });
 
@@ -167,7 +207,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[0].state).toEqual('accepted');
             expect(state.stories[1].state).toEqual('accepted');
             expect(state.stories[1].id).toEqual(newStory.id);
-
           });
         });
       });
@@ -190,7 +229,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[1].state).toEqual('delivered');
             expect(state.stories[2].state).toEqual('delivered');
             expect(state.stories[1].id).toEqual(newStory.id);
-
           });
         });
 
@@ -210,7 +248,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[1].state).toEqual('delivered');
             expect(state.stories[2].state).toEqual('delivered');
             expect(state.stories[2].id).toEqual(newStory.id);
-
           });
         });
       });
@@ -233,7 +270,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[4].state).toEqual('started');
             expect(state.stories[5].state).toEqual('started');
             expect(state.stories[4].id).toEqual(newStory.id);
-
           });
         });
 
@@ -253,7 +289,6 @@ describe('Backlog Column reducer', () => {
             expect(state.stories[4].state).toEqual('started');
             expect(state.stories[5].state).toEqual('started');
             expect(state.stories[5].id).toEqual(newStory.id);
-
           });
         });
       });


### PR DESCRIPTION
[Task link ](https://central.cm42.io/projects/central-board-v2#story-22527)

The group by sprints was being done directly in the component, now is store responsibility.