### PR TITLE
added story description and notes to sortable canceled elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fixed locale change when accessing user edit page
+- Fixed `story-description` and `.note` by adding to sortable column canceled elements/nodes
 
 ### Changed
 - pusherSockets.js to allow empty pusher env vars

--- a/app/assets/javascripts/views/column_view.js
+++ b/app/assets/javascripts/views/column_view.js
@@ -51,7 +51,7 @@ module.exports = Backbone.View.extend({
     this.storyColumn().sortable({
       opacity: 0.6,
       items: ".story:not(.accepted)",
-      cancel: ".story-description, .note",
+      cancel: ".story-description, .note, .form-control",
       connectWith: this.data.connect,
       update: function(ev, ui) {
         ui.item.trigger("sortupdate", ev, ui);

--- a/app/assets/javascripts/views/column_view.js
+++ b/app/assets/javascripts/views/column_view.js
@@ -51,6 +51,7 @@ module.exports = Backbone.View.extend({
     this.storyColumn().sortable({
       opacity: 0.6,
       items: ".story:not(.accepted)",
+      cancel: ".story-description, .note",
       connectWith: this.data.connect,
       update: function(ev, ui) {
         ui.item.trigger("sortupdate", ev, ui);


### PR DESCRIPTION
As reported on the issue #353 , the text inside a story note was not selectable.

Adding `.story-description`, `.notes` and `.form-control` to `cancel` elements prevents the `drag n' drop` event from triggering, consequently, allowing the text inside the element to be selected.