### PR TITLE
Fix calculation of first sprint size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed locale change when accessing user edit page
 - Fixed Project delete
 - Fixed `story-description` and `.note` by adding to sortable column canceled elements/nodes
+- Fix calculation of first sprint size
 
 
 ### Changed

--- a/app/models/iterations/project_iterations.rb
+++ b/app/models/iterations/project_iterations.rb
@@ -7,13 +7,13 @@ module Iterations
     end
 
     def current_iteration_start
-      project_start_date + (length * iteration_length_in_days)
+      first_sprint_start_date + (length * iteration_length_in_days)
     end
 
     def past_iterations
       (0...length).map do |iteration_number|
-        start_at = start_date(iteration_number)
-        end_at = end_date(start_at)
+        start_at = interation_start_date(iteration_number)
+        end_at = interation_end_date(start_at)
 
         PastIteration.new(
           start_date: start_at,
@@ -53,21 +53,25 @@ module Iterations
       project.iteration_length * DAYS_IN_A_WEEK
     end
 
-    def project_start_date
-      project.start_date
+    def project_start_from_first_sprint
+      project.start_date.wday - project.iteration_start_day
     end
 
-    def start_date(iteration_number)
+    def first_sprint_start_date
+      project.start_date - project_start_from_first_sprint
+    end
+
+    def interation_start_date(iteration_number)
       iteration_days = (iteration_number * iteration_length_in_days)
-      (project_start_date + iteration_days)
+      (first_sprint_start_date + iteration_days)
     end
 
-    def end_date(start_date)
+    def interation_end_date(start_date)
       (start_date + (iteration_length_in_days - 1))
     end
 
     def days_since_project_start
-      Date.current - project_start_date
+      Date.current - first_sprint_start_date
     end
   end
 end

--- a/app/models/iterations/project_iterations.rb
+++ b/app/models/iterations/project_iterations.rb
@@ -7,13 +7,13 @@ module Iterations
     end
 
     def current_iteration_start
-      first_sprint_start_date + (length * iteration_length_in_days)
+      first_iteration_start_date + (number_of_iterations * iteration_length_in_days)
     end
 
     def past_iterations
-      (0...length).map do |iteration_number|
-        start_at = interation_start_date(iteration_number)
-        end_at = interation_end_date(start_at)
+      (0...number_of_iterations).map do |iteration_number|
+        start_at = iteration_start_date(iteration_number)
+        end_at = iteration_end_date(start_at)
 
         PastIteration.new(
           start_date: start_at,
@@ -45,33 +45,33 @@ module Iterations
       end
     end
 
-    def length
-      (days_since_project_start / iteration_length_in_days).floor
+    def missing_days_from_first_sprint
+      project.start_date.wday - project.iteration_start_day
+    end
+
+    def first_iteration_start_date
+      project.start_date - missing_days_from_first_sprint
+    end
+
+    def number_of_iterations
+      (days_since_first_iteration_start / iteration_length_in_days).floor
     end
 
     def iteration_length_in_days
       project.iteration_length * DAYS_IN_A_WEEK
     end
 
-    def project_start_from_first_sprint
-      project.start_date.wday - project.iteration_start_day
+    def iteration_start_date(iteration_number)
+      iteration_days = iteration_number * iteration_length_in_days
+      first_iteration_start_date + iteration_days
     end
 
-    def first_sprint_start_date
-      project.start_date - project_start_from_first_sprint
+    def iteration_end_date(start_date)
+      start_date + (iteration_length_in_days - 1)
     end
 
-    def interation_start_date(iteration_number)
-      iteration_days = (iteration_number * iteration_length_in_days)
-      (first_sprint_start_date + iteration_days)
-    end
-
-    def interation_end_date(start_date)
-      (start_date + (iteration_length_in_days - 1))
-    end
-
-    def days_since_project_start
-      Date.current - first_sprint_start_date
+    def days_since_first_iteration_start
+      Date.current - first_iteration_start_date
     end
   end
 end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     iteration_start_day { Time.current.days_ago(10).wday }
   end
 
-  trait :with_month_ago do
+  trait :created_one_month_ago do
     created_at { Time.current.months_ago(1) }
     start_date { Time.current.months_ago(1) }
     iteration_start_day { Time.current.months_ago(1).wday }

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -8,10 +8,12 @@ FactoryGirl.define do
   trait :with_past_iteration do
     created_at { Time.current.days_ago(10) }
     start_date { Time.current.days_ago(10) }
+    iteration_start_day { Time.current.days_ago(10).wday }
   end
 
   trait :with_month_ago do
     created_at { Time.current.months_ago(1) }
     start_date { Time.current.months_ago(1) }
+    iteration_start_day { Time.current.months_ago(1).wday }
   end
 end

--- a/spec/models/iterations/project_iterations_spec.rb
+++ b/spec/models/iterations/project_iterations_spec.rb
@@ -23,6 +23,13 @@ module Iterations
         let(:story) { create(:story, :done, :with_project) }
         let(:project) { story.project }
 
+        before do
+          project.start_date = Time.current.days_ago(14)
+          project.iteration_start_day = Time.current.days_ago(16).wday
+          # first iteration goes 16.days_ago -- 10.days_ago
+          # second iteration goes 9.days_ago -- 3.days_ago
+        end
+
         it 'all past iterations must start in the iteration_start_day' do
           project.start_date = Time.current.days_ago(14)
           project.iteration_start_day = Time.current.days_ago(16).wday
@@ -33,8 +40,8 @@ module Iterations
         end
 
         it 'considers the length of the first iteration to calculate the second iteration stories' do
-          project.start_date -= 21.days
-          story.accepted_at -= 17.days
+          story.accepted_at = Time.current.days_ago(7)
+          story.save
 
           second_iteration = subject.past_iterations[1]
           expect(second_iteration.stories).to include(story)
@@ -42,10 +49,6 @@ module Iterations
 
         context 'when story is accepted in the last day of iteration' do
           before do
-            project.start_date = Time.current.days_ago(14)
-            project.iteration_start_day = Time.current.days_ago(16).wday 
-            # first iteration goes 16.days_ago -- 10.days_ago
-
             story.accepted_at = Time.current.days_ago(10)
             story.save
           end

--- a/spec/models/iterations/project_iterations_spec.rb
+++ b/spec/models/iterations/project_iterations_spec.rb
@@ -8,7 +8,7 @@ module Iterations
       let(:project) { create(:project) }
 
       it 'returns the current iteration start date' do
-        expect(subject.current_iteration_start).to eq(DateTime.current.to_date)
+        expect(subject.current_iteration_start.wday).to eq(project.iteration_start_day)
       end
     end
 
@@ -17,6 +17,30 @@ module Iterations
 
       it 'returns a past iteration' do
         expect(subject.past_iterations).to all(be_a(PastIteration))
+      end
+
+      context "when project didn't start in the same week day as the iterations" do
+        let(:story) { create(:story, :done, :with_project) }
+        let(:project) { story.project }
+
+        it 'all past iterations must start in the iteration_start_day' do
+          interation_start_day = 0
+          project.iteration_start_day = interation_start_day
+          project.start_date += interation_start_day + 1
+          project.start_date -= 3.weeks
+
+          past_iterations_start_date = subject.past_iterations.map{ |iteration| iteration.start_date.wday }
+
+          expect(past_iterations_start_date).to all(be project.iteration_start_day)
+        end
+
+        it 'considers the length of the first iteration to calculate the second iteration stories' do
+          project.start_date -= 21.days
+          story.accepted_at -= 17.days
+
+          second_iteration = subject.past_iterations[1]
+          expect(second_iteration.stories).to include(story)
+        end
       end
     end
   end

--- a/spec/models/iterations/project_iterations_spec.rb
+++ b/spec/models/iterations/project_iterations_spec.rb
@@ -24,10 +24,8 @@ module Iterations
         let(:project) { story.project }
 
         it 'all past iterations must start in the iteration_start_day' do
-          interation_start_day = 0
-          project.iteration_start_day = interation_start_day
-          project.start_date += interation_start_day + 1
-          project.start_date -= 3.weeks
+          project.start_date = Time.current.days_ago(14)
+          project.iteration_start_day = Time.current.days_ago(16).wday
 
           past_iterations_start_date = subject.past_iterations.map{ |iteration| iteration.start_date.wday }
 
@@ -40,6 +38,27 @@ module Iterations
 
           second_iteration = subject.past_iterations[1]
           expect(second_iteration.stories).to include(story)
+        end
+
+        context 'when story is accepted in the last day of iteration' do
+          before do
+            project.start_date = Time.current.days_ago(14)
+            project.iteration_start_day = Time.current.days_ago(16).wday 
+            # first iteration goes 16.days_ago -- 10.days_ago
+
+            story.accepted_at = Time.current.days_ago(10)
+            story.save
+          end
+
+          it 'should be in the first iteration' do
+            first_iteration = subject.past_iterations[0]
+            expect(first_iteration.stories).to include(story)
+          end
+
+          it "shouldn't be in the first iteration" do
+            second_iteration = subject.past_iterations[1]
+            expect(second_iteration.stories).not_to include(story)
+          end
         end
       end
     end

--- a/spec/models/iterations/project_iterations_spec.rb
+++ b/spec/models/iterations/project_iterations_spec.rb
@@ -41,7 +41,7 @@ module Iterations
 
         it 'considers the length of the first iteration to calculate the second iteration stories' do
           story.accepted_at = Time.current.days_ago(7)
-          story.save
+          story.save!
 
           second_iteration = subject.past_iterations[1]
           expect(second_iteration.stories).to include(story)
@@ -50,7 +50,7 @@ module Iterations
         context 'when story is accepted in the last day of iteration' do
           before do
             story.accepted_at = Time.current.days_ago(10)
-            story.save
+            story.save!
           end
 
           it 'should be in the first iteration' do

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -467,7 +467,7 @@ describe StoryOperations do
     end
 
     context 'when the project started a month ago' do
-      let(:project) { create(:project, :with_month_ago, users: [user], teams: [current_team]) }
+      let(:project) { create(:project, :created_one_month_ago, users: [user], teams: [current_team]) }
       let(:iteration_length)         { project.iteration_length * 7 }
       let(:days_since_project_start) { (Date.current - project.start_date).to_i }
       let(:number_of_iterations)     { days_since_project_start / iteration_length }


### PR DESCRIPTION
Fix calculation of first sprint size when the project start date differs of iteration start date.
- Change the calculate to use iteration start date instead of project start date