### PR TITLE
Fix Project delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fixed locale change when accessing user edit page
+- Fixed Project delete
 
 ### Changed
 - pusherSockets.js to allow empty pusher env vars

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -61,6 +61,7 @@ class Story < ApplicationRecord
   end
 
   def readonly?
+    return false if destroyed_by_association
     !accepted_at_changed? && accepted_at.present?
   end
 


### PR DESCRIPTION
Project delete was failing when some of his stories were set to readonly (when accepted) and raising `ActiveRecord::ReadOnlyRecord`.
- Change `Story#readonly?` to return false when destroyed by association (Project).