### PR TITLE
Fallback to long polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix pusher missing api key
 
 ## [1.21.1] 2018-10-18
 ### Fixed

--- a/app/assets/javascripts/pusherSockets.js
+++ b/app/assets/javascripts/pusherSockets.js
@@ -6,12 +6,12 @@ const matchPusherUrl = url => {
 };
 
 export const subscribeToProjectChanges = (project, callback) => {
-  const pusherUrl = process.env.PUSHER_SOCKET_URL;
+  const pusherUrl = process.env.PUSHER_SOCKET_URL || '';
   const [
     _,
     pusherCluster,
     pusherApiKey
-  ] = matchPusherUrl(pusherUrl || '') || [];
+  ] = matchPusherUrl(pusherUrl) || [];
 
   if (!pusherApiKey || !pusherCluster) {
     setInterval(callback, 10 * 1000); // every 10 seconds

--- a/app/assets/javascripts/pusherSockets.js
+++ b/app/assets/javascripts/pusherSockets.js
@@ -11,9 +11,10 @@ export const subscribeToProjectChanges = (project, callback) => {
     _,
     pusherCluster,
     pusherApiKey
-  ] = matchPusherUrl(pusherUrl) || [];
+  ] = matchPusherUrl(pusherUrl || '') || [];
 
   if (!pusherApiKey || !pusherCluster) {
+    setInterval(callback, 10 * 1000); // every 10 seconds
     return;
   }
 


### PR DESCRIPTION
- Add fallback to long polling when pusher API key is missing.
Reference: [#400](https://github.com/Codeminer42/cm42-central/issues/400)