### PR TITLE
Fix project delete 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix project delete when tasks or notes are readonly
 
 ## [1.21.1] 2018-10-18
 ### Fixed

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -5,6 +5,11 @@ class Note < ApplicationRecord
   before_save :cache_user_name
   before_destroy { |record| raise ActiveRecord::ReadOnlyRecord if record.readonly? }
 
+  def readonly?
+    return false if destroyed_by_association
+    story.readonly?
+  end
+
   validates :note, presence: true
 
   delegate :project, to: :story
@@ -20,8 +25,6 @@ class Note < ApplicationRecord
 
     "#{note} (#{user_name} - #{created_date})"
   end
-
-  delegate :readonly?, to: :story
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,5 +5,8 @@ class Task < ApplicationRecord
 
   before_destroy { |record| raise ActiveRecord::ReadOnlyRecord if record.readonly? }
 
-  delegate :readonly?, to: :story
+  def readonly?
+    return false if destroyed_by_association
+    story.readonly?
+  end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -37,28 +37,30 @@ describe Note do
   describe '#readonly?' do
     let(:user) { create(:user) }
     let(:project) { create(:project) }
+    let(:story) { create(:story, project: project, requested_by: user) }
+    let(:note) { create(:note, user: user, story: story) }
 
     before do
       project.users << user
-      project.suppress_notifications = true
-      @story = create(:story, project: project, requested_by: user)
-      @note = create(:note, user: user, story: @story)
-
-      @story.update_attribute(:state, 'accepted')
+      story.update_attribute(:state, 'accepted')
     end
 
     it "can't modify a note from a readonly story" do
-      expect { @note.update_attribute(:note, 'new note') }
+      expect { note.update_attribute(:note, 'new note') }
         .to raise_error(ActiveRecord::ReadOnlyRecord)
     end
 
     it "can't let the note from an accepted story to be destroyed" do
-      expect { @note.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect { note.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord)
     end
 
     it "can't add more notes to an accepted story" do
-      expect { @story.notes.create(note: 'test', user: user) }
+      expect { story.notes.create(note: 'test', user: user) }
         .to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it 'can destroy read_only note when deleting the project' do
+      expect { project.destroy }.not_to raise_error
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -25,26 +25,30 @@ describe Task do
   describe '#readonly?' do
     let(:user) { create(:user) }
     let(:project) { create(:project) }
+    let(:story) { create(:story, project: project, requested_by: user) }
+    let(:task) { create(:task, story: story) }
 
     before do
       project.users << user
       project.suppress_notifications = true
-      @story = create(:story, project: project, requested_by: user)
-      @task = create(:task, story: @story)
 
-      @story.update_attribute(:state, 'accepted')
+      story.update_attribute(:state, 'accepted')
     end
 
     it "can't modify a task from a readonly story" do
-      expect { @task.update_attribute(:done, true) }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect { task.update_attribute(:done, true) }.to raise_error(ActiveRecord::ReadOnlyRecord)
     end
 
     it "can't let the task from an accepted story to be destroyed" do
-      expect { @task.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect { task.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord)
     end
 
     it "can't add more tasks to an accepted story" do
-      expect { @story.tasks.create(name: 'test') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      expect { story.tasks.create(name: 'test') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it 'can destroy read_only task when deleting the project' do
+      expect { project.destroy }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
When trying to destroy a project, and that one has a story already accepted with tasks or notes was accusing the error `ActiveRecord::ReadOnlyRecord`.

- Override the method `readonly?` instead of delegate to story, to accept be destroyed by association.