### PR TITLE
Remove unnecessary response with stories in past iterations

### DIFF
--- a/app/models/iterations/past_iteration.rb
+++ b/app/models/iterations/past_iteration.rb
@@ -8,8 +8,5 @@ module Iterations
     attribute :stories, Array[Story]
     attribute :points, Integer
 
-    def points
-      @points ||= stories.to_a.map(&:estimate).compact.sum
-    end
   end
 end

--- a/app/models/iterations/past_iteration.rb
+++ b/app/models/iterations/past_iteration.rb
@@ -8,5 +8,8 @@ module Iterations
     attribute :stories, Array[Story]
     attribute :points, Integer
 
+    def points
+      @points ||= stories.to_a.map(&:estimate).compact.sum
+    end
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -19,6 +19,14 @@ class Story < ApplicationRecord
     end
   end
 
+  scope :accepted, -> { where(state: 'accepted').where.not(accepted_at: nil) }
+  
+  scope :accepted_between, ->(start_date, end_date) {
+                             where('accepted_at >= ? AND accepted_at <= ?',
+                               start_date.beginning_of_day,
+                               end_date.end_of_day)
+                           }
+
   has_many :changesets, dependent: :destroy
   has_many :tasks, dependent: :destroy
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -20,8 +20,8 @@ class Story < ApplicationRecord
   end
 
   scope :accepted, -> { where(state: 'accepted').where.not(accepted_at: nil) }
-  
-  scope :accepted_between, ->(start_date, end_date) {
+
+  scope :accepted_between, lambda(start_date, end_date) {
                              where('accepted_at >= ? AND accepted_at <= ?',
                                start_date.beginning_of_day,
                                end_date.end_of_day)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -21,7 +21,7 @@ class Story < ApplicationRecord
 
   scope :accepted, -> { where(state: 'accepted').where.not(accepted_at: nil) }
 
-  scope :accepted_between, lambda(start_date, end_date) {
+  scope :accepted_between, lambda { |start_date, end_date|
                              where('accepted_at >= ? AND accepted_at <= ?',
                                start_date.beginning_of_day,
                                end_date.end_of_day)

--- a/app/operations/iteration_operations.rb
+++ b/app/operations/iteration_operations.rb
@@ -33,11 +33,7 @@ module IterationOperations
         project
           .stories
           .with_dependencies
-          .where(
-            'accepted_at >= ? AND accepted_at <= ?',
-            start_date.beginning_of_day,
-            end_date.end_of_day
-          )
+          .accepted_between(start_date, end_date)
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ ActiveRecord::Base.transaction do
   project = Project.create!(
     name: 'Test Project',
     users: [user],
-    start_date: Time.current.months_ago(1)
+    start_date: Time.current.months_ago(2)
   )
 
   project.stories.create!(
@@ -60,6 +60,20 @@ ActiveRecord::Base.transaction do
       started_at: Time.current.weeks_ago(n + 1),
       requested_by: user,
       estimate: 3,
+      labels: 'features'
+    )
+  end
+
+  60.times do |n|
+    random_date = [*1...6].sample
+    project.stories.create!(
+      title: "Story #{n}",
+      story_type: 'feature',
+      state: 'accepted',
+      accepted_at:  Time.current.weeks_ago(random_date),
+      started_at: Time.current.weeks_ago(random_date + 1),
+      requested_by: user,
+      estimate: [*1...4].sample,
       labels: 'features'
     )
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -40,8 +40,15 @@ describe Story do
     let!(:story) { create(:story, :done, project: project, requested_by: user) }
 
     context '.accepted' do
-      it 'must include story' do
+      it 'include accepted story' do
         expect(Story.accepted).to include(story)
+      end
+
+      it 'not include non accepted story' do
+        story.accepted_at = nil
+        story.save!
+
+        expect(Story.accepted).not_to include(story)
       end
     end
 
@@ -49,13 +56,25 @@ describe Story do
       let(:start_date) { Time.current.days_ago(16) }
       let(:end_date) { Time.current.days_ago(14) }
 
-      before do
-        story.accepted_at = Time.current.days_ago(15)
+      it 'include story accepted beetween start_date and end_date' do
+        story.accepted_at = start_date + 2.days
         story.save!
+
+        expect(Story.accepted_between(start_date, end_date)).to include(story)
       end
 
-      it 'must include story' do
-        expect(Story.accepted_between(start_date, end_date)).to include(story)
+      it 'not include story accepted before start_date' do
+        story.accepted_at = start_date - 1.day
+        story.save!
+
+        expect(Story.accepted_between(start_date, end_date)).not_to include(story)
+      end
+
+      it 'not include story accepted after end_date' do
+        story.accepted_at = end_date + 1.day
+        story.save!
+
+        expect(Story.accepted_between(start_date, end_date)).not_to include(story)
       end
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -28,6 +28,38 @@ describe Story do
     end
   end
 
+  describe 'scopes' do
+    let!(:user) { create(:user, :with_team) }
+
+    let!(:project) do
+      create(:project,
+              users: [user],
+              teams: [user.teams.first])
+    end
+
+    let!(:story) { create(:story, :done, project: project, requested_by: user) }
+
+    context '.accepted' do
+      it 'must include story' do
+        expect(Story.accepted).to include(story)
+      end
+    end
+
+    context '.accepted_between()' do
+      let(:start_date) { Time.current.days_ago(16) }
+      let(:end_date) { Time.current.days_ago(14) }
+
+      before do
+        story.accepted_at = Time.current.days_ago(15)
+        story.save!
+      end
+
+      it 'must include story' do
+        expect(Story.accepted_between(start_date, end_date)).to include(story)
+      end
+    end
+  end
+
   describe '#readonly?' do
     subject { create :story, :with_project }
 

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -415,7 +415,8 @@ describe StoryOperations do
       iteration_end = ((project.created_at + project.iteration_length * 7.days) - 1.day).to_date
       Iterations::PastIteration.new(start_date: iteration_start,
                                     end_date: iteration_end,
-                                    stories: [done_story])
+                                    stories: [],
+                                    points: done_story.estimate)
     end
 
     subject      { StoryOperations::ReadAll }


### PR DESCRIPTION
- Remove stories property in past_iterations when calling it for the first time.
- Refactor iteration model and operation
	modified:   app/models/iterations/past_iteration.rb
	modified:   app/models/iterations/project_iterations.rb
	modified:   app/models/story.rb
	modified:   app/operations/iteration_operations.rb