### PR TITLE
Fix special character in project title

### DIFF
--- a/app/assets/javascripts/components/projects/ProjectCard.js
+++ b/app/assets/javascripts/components/projects/ProjectCard.js
@@ -1,11 +1,16 @@
 import React from 'react';
 
 export default class ProjectCard extends React.Component {
+  decodeHTML(html) {
+    const txt = document.createElement('textarea');
+    txt.innerHTML = html;
+    return txt.value;
+  };
 
   renderTag(project) {
     if (!project.get('tag_name')) { return; }
 
-    let style = {
+    const style = {
       backgroundColor: project.get('tag_bg_color'),
       color: project.get('tag_fore_color')
     };
@@ -17,14 +22,20 @@ export default class ProjectCard extends React.Component {
     );
   }
 
+  projectName(){
+    return this.decodeHTML(this.props.project.get('name')); 
+  }
+
   panelHeading() {
     const { project, joined } = this.props;
 
     if (joined) {
       return(
         <div className="panel-heading card-heading">
-          <div>
-            <a href={ project.get('path_to').project } className="card-title project-title">{ project.get('name') }</a>
+          <div className="project-card-header-container">
+            <a href={ project.get('path_to').project } className="card-title project-title">
+              { this.projectName() }              
+            </a>
             { this.renderTag(project) }
           </div>
           <div className="icons pull-right">
@@ -85,8 +96,10 @@ export default class ProjectCard extends React.Component {
     }
 
     return(
-      <div className="panel-heading">
-        <span href={ project.get('path_to').project } className="card-title">{ project.get('name') }</span>
+      <div className="panel-heading card-heading">
+        <span className="card-title">
+          { this.projectName() }
+        </span>
       </div>
     );
   }

--- a/spec/javascripts/components/projects/project_card_spec.js
+++ b/spec/javascripts/components/projects/project_card_spec.js
@@ -206,8 +206,8 @@ describe('<ProjectCard />', () => {
 
       const wrapper = shallow(<ProjectCard {...defaultProps} />);
       expect(wrapper.contains(
-        <div className="panel-heading">
-          <span href="/projects/foobar" className="card-title">Foobar</span>
+        <div className="panel-heading card-heading">
+          <span className="card-title">Foobar</span>
         </div>
       )).toBe(true);
     });


### PR DESCRIPTION
It was necessary to decode HTML entities to appear the right content.

Ref: [#story-23199](https://central.cm42.io/projects/central#story-23199)

Before
![image](https://user-images.githubusercontent.com/15300776/48906068-79028900-ee4a-11e8-9b8c-896417a1f76c.png)

After
![image](https://user-images.githubusercontent.com/15300776/48906077-83248780-ee4a-11e8-89a3-9f53f01ae53b.png)

