### PR TITLE
Feature/fix reports

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -92,16 +92,8 @@ module ProjectsHelper
     @backlog_date.last.to_date.to_s(:short)
   end
 
-  def total_backlog_points
-    stories = @service.instance_variable_get('@stories')
-    stories.each do |story|
-      story.delete if story[:state] == "accepted"
-    end
-    stories.map(&:estimate).compact.sum
-  end
-
   def calculate_and_render_burn_up!
-    @group_by_day = BurnUpCalculator.call(@project)
+    @report_data = BurnUpCalculator.call(@project)
   end
 
   def burn_down_data

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -92,6 +92,14 @@ module ProjectsHelper
     @backlog_date.last.to_date.to_s(:short)
   end
 
+  def total_backlog_points
+    stories = @service.instance_variable_get('@stories')
+    stories.each do |story|
+      story.delete if story[:state] == "accepted"
+    end
+    stories.map(&:estimate).compact.sum
+  end
+
   def calculate_and_render_burn_up!
     @group_by_day = BurnUpCalculator.call(@project)
   end

--- a/app/services/burn_up_calculator.rb
+++ b/app/services/burn_up_calculator.rb
@@ -21,13 +21,8 @@ class BurnUpCalculator
     ]
   end
 
-  def total_backlog_points
-    stories = service_full.instance_variable_get('@stories')
-    stories.map(&:estimate).compact.sum
-  end
-
   def points_per_day
-    @points_per_day ||= total_backlog_points.to_f / service_full.group_by_day.keys.size
+    @points_per_day ||= @total_backlog_points.to_f / service_full.group_by_day.keys.size
   end
 
   def calculate_points

--- a/app/services/burn_up_calculator.rb
+++ b/app/services/burn_up_calculator.rb
@@ -6,7 +6,7 @@ class BurnUpCalculator
 
     calculate_points
 
-    @group_by_day
+    @report_data
   end
 
   private
@@ -14,15 +14,23 @@ class BurnUpCalculator
   attr_reader :service_full
 
   def initialize_group_by_day
-    @group_by_day = [
-      { name: 'today', data: { Date.current => service_full.group_by_day[Date.current] } },
-      { name: 'real',  data: service_full.group_by_day },
-      { name: 'ideal', data: service_full.group_by_day.dup }
-    ]
+    @report_data = {
+      group_by_day: [
+        { name: 'today', data: { Date.current => service_full.group_by_day[Date.current] } },
+        { name: 'real',  data: service_full.group_by_day },
+        { name: 'ideal', data: service_full.group_by_day.dup }
+      ],
+      total_backlog_points: total_backlog_points
+    }
+  end
+
+  def total_backlog_points
+    stories = service_full.instance_variable_get('@stories')
+    stories.reject(&:accepted?).map(&:estimate).compact.sum
   end
 
   def points_per_day
-    @points_per_day ||= @total_backlog_points.to_f / service_full.group_by_day.keys.size
+    @points_per_day ||= total_backlog_points.to_f / service_full.group_by_day.keys.size
   end
 
   def calculate_points
@@ -30,8 +38,8 @@ class BurnUpCalculator
 
     initialize_group_by_day
 
-    @group_by_day.last[:data].keys.each do |key|
-      @group_by_day.last[:data][key] = initial_points
+    @report_data[:group_by_day].last[:data].keys.each do |key|
+      @report_data[:group_by_day].last[:data][key] = initial_points
       initial_points += points_per_day
     end
   end

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -70,7 +70,7 @@
       <div class="panel-body">
         <% calculate_and_render_burn_up! %>
 
-        <p><%= t('projects.reports.burn_up.backlog_points_html', count: total_backlog_points) %></p>
+        <p><%= t('projects.reports.burn_up.backlog_points_html', count: @report_data[:total_backlog_points]) %></p>
         <p>
           <%= t('projects.reports.burn_up.remaining_time',
                 velocity: @service.velocity,
@@ -89,7 +89,7 @@
           </p>
         <% end %>
 
-        <p><%= area_chart @group_by_day, max: total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
+        <p><%= area_chart @report_data[:group_by_day], max: @report_data[:total_backlog_points], xtitle: t('day'), ytitle: t('accepted_points') %></p>
       </div>
     </div>
 

--- a/app/views/projects/reports.html.erb
+++ b/app/views/projects/reports.html.erb
@@ -70,7 +70,7 @@
       <div class="panel-body">
         <% calculate_and_render_burn_up! %>
 
-        <p><%= t('projects.reports.burn_up.backlog_points_html', count: @total_backlog_points) %></p>
+        <p><%= t('projects.reports.burn_up.backlog_points_html', count: total_backlog_points) %></p>
         <p>
           <%= t('projects.reports.burn_up.remaining_time',
                 velocity: @service.velocity,
@@ -89,7 +89,7 @@
           </p>
         <% end %>
 
-        <p><%= area_chart @group_by_day, max: @total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
+        <p><%= area_chart @group_by_day, max: total_backlog_points, xtitle: t('day'), ytitle: t('accepted_points') %></p>
       </div>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,7 +260,7 @@ en:
         title: "Velocity per Member"
       burn_up:
         title: "Burn Up Chart"
-        backlog_points_html: "The current backlog has a total of <strong>%{count} points</strong>. This is without counting the stories in the Chilly Bean!"
+        backlog_points_html: "The current backlog has a total of <strong>%{count} points</strong>. This is without counting the stories in the Chilly Bin!"
         remaining_time: "At the current velocity (%{velocity} points) the existing backlog should only be finished around the iteration %{last_iteration_number} (%{last_iteration_start_date})."
         on_track: "If the velocity keeps up this pace we should be on track to the date above."
         realistic_remaining_time: "But with a standard deviation of %{standard_deviation}, it's more realistic to expect the project to finish around <strong>iteration %{last_iteration_number}</strong> (%{last_iteration_start_date}), if the velocity doesn't increase or the backlog is not simplified."

--- a/spec/services/burn_up_calculator_spec.rb
+++ b/spec/services/burn_up_calculator_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe BurnUpCalculator do
   let(:service_full)  { double(:service_full) }
   let(:project)       { double(:project, name: 'Central') }
-  let(:story1)        { double(:story1, estimate: 3) }
-  let(:story2)        { double(:story2, estimate: 8) }
+  let(:story1)        { double(:story1, estimate: 3, state: 'unstarted', accepted?: false) }
+  let(:story2)        { double(:story2, estimate: 8, state: 'unstarted', accepted?: false) }
   let(:stories)       { [story1, story2] }
 
   let(:yesterday) { Date.current - 1.day }
@@ -28,9 +28,9 @@ describe BurnUpCalculator do
   end
 
   describe '#call' do
-    it 'returns classified points' do
+    it 'returns classified points and the total backlog points' do
       expect(subject).to eq(
-        [
+        group_by_day: [
           {
             name: 'today',
             data: { today => 1 }
@@ -43,7 +43,8 @@ describe BurnUpCalculator do
             name: 'ideal',
             data: { yesterday => 0, today => 3.6666666666666665, tomorrow => 7.333333333333333 }
           }
-        ]
+        ],
+        total_backlog_points: 11
       )
     end
   end


### PR DESCRIPTION
The report page on the project wasn't showing the amount of points remaining in the backlog for the project to be completed and the graph was also not being displayed properly.
![image](https://user-images.githubusercontent.com/33486409/50983484-b00a2800-14e6-11e9-8576-bb94062c1925.png)

This was happening because the report view wasn't getting the data it needed to display these numbers. The changes on `burn_up_calculator.rb` were made so that the view could get the data it needed. The estimate and the charts are now displaying the data correctly.
![image](https://user-images.githubusercontent.com/33486409/50983694-21e27180-14e7-11e9-877e-4a04e648e140.png)

Also there was a fix to a small typo on the english translation (`Chilly Bean` to `Chilly Bin`)