### PR TITLE
Now an error returns when a team is created wrongly

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -23,9 +23,7 @@ class NotesController < ApplicationController
     @note = policy_scope(Note).build(allowed_params)
     authorize @note
     @note.user = current_user
-    @note = NoteOperations::Create.call(@note, current_user)
-
-    if @note
+    if NoteOperations::Create.call(@note, current_user)
       render json: @note
     else
       render json: @note, status: :unprocessable_entity

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -33,9 +33,7 @@ class StoriesController < ApplicationController
     @story.acting_user = current_user
     @story.base_uri = project_url(@story.project)
     respond_to do |format|
-      @updater = StoryOperations::Update.call(@story, allowed_params, current_user)
-
-      if @updater
+      if StoryOperations::Update.call(@story, allowed_params, current_user)
         format.html { redirect_to project_url(@project) }
         format.js   { render json: @story }
       else
@@ -75,9 +73,7 @@ class StoriesController < ApplicationController
     authorize @story
     @story.requested_by_id = current_user.id unless @story.requested_by_id
     respond_to do |format|
-      @updater = StoryOperations::Create.call(@story, current_user)
-
-      if @updater
+      if StoryOperations::Create.call(@story, current_user)
         format.html { redirect_to project_url(@project) }
         format.js   { render json: @story }
       else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -143,7 +143,7 @@ class TeamsController < ApplicationController
   end
 
   def can_create?
-    check_recaptcha && (@team = TeamOperations::Create.call(@team, current_user))
+    check_recaptcha && TeamOperations::Create.call(@team, current_user)
   end
 
   def add_team_for(user)

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -18,7 +18,7 @@ ActionController::Renderers.add :csv do |stories, options|
     end
   end
 
-  send_data csv_string, type: Mime::CSV, filename: filename
+  send_data csv_string, type: Mime[:csv], filename: filename
 
 end
 

--- a/spec/features/notes_spec.rb
+++ b/spec/features/notes_spec.rb
@@ -49,19 +49,6 @@ describe 'Notes' do
       sleep 0.5
       expect(find('#in_progress .story .notelist')).not_to have_content('Delete me please')
     end
-
-    it 'does not save an invalid note', js: true do
-      visit project_path(project)
-
-      within('#in_progress .story') do
-        find('.story-title').trigger('click')
-        fill_in 'note', with: nil
-        click_on 'Add note'
-      end
-
-      sleep 0.5
-      expect(page).to have_no_css('.note')
-    end
   end
 
   describe 'on a disabled story' do

--- a/spec/features/notes_spec.rb
+++ b/spec/features/notes_spec.rb
@@ -49,6 +49,19 @@ describe 'Notes' do
       sleep 0.5
       expect(find('#in_progress .story .notelist')).not_to have_content('Delete me please')
     end
+
+    it 'does not save an invalid note', js: true do
+      visit project_path(project)
+
+      within('#in_progress .story') do
+        find('.story-title').trigger('click')
+        fill_in 'note', with: nil
+        click_on 'Add note'
+      end
+
+      sleep 0.5
+      expect(page).to have_no_css('.note')
+    end
   end
 
   describe 'on a disabled story' do

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -7,14 +7,35 @@ describe 'Teams' do
     let!(:user) { create :user, :with_team }
 
     describe 'create team' do
-      it 'should create a new team and set the user as admin' do
+      before do
         visit teams_path
         click_link 'Create new team'
-
+      end
+      
+      it 'should create a new team and set the user as admin' do  
         fill_in 'Team Name', with: 'foobar'
         click_button 'Create new team'
 
         expect(user.teams.last.is_admin?(user)).to be_truthy
+      end
+
+      it 'fails when no team name is set' do
+        fill_in 'Team Name', with: nil
+        click_button 'Create new team'
+
+        expect(page).to have_text("Team Name can't be blank")
+      end
+
+      it 'fails when team name already exists' do
+        fill_in 'Team Name', with: 'foobar'
+        click_button 'Create new team'
+
+        visit teams_path
+        click_link 'Create new team'
+        fill_in 'Team Name', with: 'foobar'
+        click_button 'Create new team'
+
+        expect(page).to have_text('Team Name has already been taken')
       end
     end
   end


### PR DESCRIPTION
When there was an attempt to create a team with invalid parameters (e.g., without a name or with an already existing name), it should return a message explaining what the error was, but all that was returning was a generic error without any description.

With the changes made on `teams_controller.rb` the view can receive proper information to return to the user and describe what the problem was.