### PR TITLE
prevent empty tasks and notes from being added on both v1 and v2

### DIFF
--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryNotes.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryNotes.js
@@ -25,6 +25,10 @@ class ExpandedStoryNotes extends React.Component {
     this.setState({ value: '' });
   }
 
+  hasAnEmptyValue() {
+    return !this.state.value.trim()
+  }
+
   notesForm() {
     return (
       <div>
@@ -39,6 +43,7 @@ class ExpandedStoryNotes extends React.Component {
             type='button'
             value={I18n.t('add note')}
             onClick={this.handleSave}
+            disabled={this.hasAnEmptyValue()}
           />
         </div>
       </div>

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
@@ -28,6 +28,10 @@ class ExpandedStoryTask extends Component {
     });
   }
 
+  hasAnEmptyValue() {
+    return !this.state.task.trim()
+  }
+
   render() {
     const { story, onToggle, onDelete } = this.props;
 
@@ -57,6 +61,7 @@ class ExpandedStoryTask extends Component {
             type='submit'
             className='Story__add-task-button'
             onClick={this.onHandleSubmit}
+            disabled={this.hasAnEmptyValue()}
           >
             {I18n.t('add task')}
           </button>

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -784,10 +784,22 @@ module.exports = FormView.extend({
         />,
         $noteForm.get(0)
       );
-
-      $noteForm.find('textarea').atwho({
+      const addNoteButton = $noteForm.find('button')
+      const noteTextArea = $noteForm.find('textarea')
+      
+      addNoteButton.attr('disabled', 'disabled')
+      
+      noteTextArea.atwho({
         at: '@',
         data: window.projectView.usernames()
+      });
+
+      noteTextArea.keyup(function() {
+        if ($.trim(noteTextArea.val())) {
+          addNoteButton.removeAttr('disabled');
+        } else { 
+          addNoteButton.attr('disabled', 'disabled');
+        }    
       });
     }
   },
@@ -839,6 +851,18 @@ module.exports = FormView.extend({
         />,
         $taskForm.get(0)
       );
+      const addTaskButton = $taskForm.find('button')
+      const taskTextArea = $taskForm.find('input')
+
+      addTaskButton.attr('disabled', 'disabled')
+
+      taskTextArea.keyup(function() {
+        if ($.trim(taskTextArea.val())) {
+          addTaskButton.removeAttr('disabled');
+        } else { 
+          addTaskButton.attr('disabled', 'disabled');
+        }    
+      });
     }
   },
 

--- a/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
@@ -42,6 +42,24 @@ describe('<ExpandedStoryNotes />', () => {
     expect(wrapper.find('NotesList')).toExist();
   });
 
+  it('disables the add note button if text area is empty', ()=>{
+    const story = { notes: [] };
+
+    const wrapper = shallow(
+      <ExpandedStoryNotes
+        story={story}
+        onCreate={onCreate}
+        onDelete={onDelete}
+      />
+    );
+    
+    const textArea = wrapper.find('.create-note-text');
+    const button = wrapper.find('.create-note-button input');
+
+    textArea.simulate('change', { target: { value: '' } });
+    expect(button.prop('disabled')).toBe(true);
+  });
+
   describe('when user create a new note', () => {
     it('triggers the onCreate callback passing the note', () => {
       const story = {

--- a/spec/javascripts/components/story/expanded_story/expanded_story_task_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_task_spec.js
@@ -26,6 +26,14 @@ describe('<ExpandedStoryTask />', () => {
     expect(wrapper.text()).toContain(I18n.t('story.tasks'));
   });
 
+  it('disables the add task button if text area is empty', ()=>{
+    const { input } = setup();
+    const { button } = setup();
+
+    input.simulate('change', { target: { value: '' } });
+    expect(button.prop('disabled')).toBe(true);
+  });
+
   describe('onHandleSubmit', () => {
     it('calls onSave with a task', () => {
       const task = 'New Task';

--- a/spec/javascripts/views/story_view_spec.js
+++ b/spec/javascripts/views/story_view_spec.js
@@ -441,6 +441,16 @@ describe('StoryView', function() {
       expect(this.view.model.notes.last().isNew()).toBeTruthy();
     });
 
+    describe("when the text area is empty", function() {
+
+      it("disables the add button", function() {
+        this.view.canEdit = sinon.stub().returns(true);
+        this.view.render();
+
+        expect(this.view.$('.add-note').is(':disabled')).toEqual(true);
+      });  
+    })
+
     it("doesn't add a blank note if the story is new", function() {
       var stub = sinon.stub(this.view.model, 'isNew');
       stub.returns(true);
@@ -482,6 +492,13 @@ describe('StoryView', function() {
       this.view.addEmptyTask();
       expect(this.view.model.tasks.length).toEqual(1);
       expect(this.view.model.tasks.last().isNew()).toBeTruthy();
+    });
+
+    it("disables the add button if the input is empty", function() {
+      this.view.canEdit = sinon.stub().returns(true);
+      this.view.render();
+
+      expect(this.view.$('.add-task').is(':disabled')).toEqual(true);
     });
 
     it("doesn't add a blank task if the story is new", function() {


### PR DESCRIPTION
When a note or task is being added to a story, the add button is disabled until the user adds any text to the text area. These changes were made on both versions of Central (v1 and v2). Here's an example:
![test-project-cm42-central](https://user-images.githubusercontent.com/33486409/51996559-25409b80-249c-11e9-9f24-33ac7cc108f6.gif)
