### PR TITLE
labels are now displayed under the collapsed story title

### DIFF
--- a/app/assets/stylesheets/new_board/_story.scss
+++ b/app/assets/stylesheets/new_board/_story.scss
@@ -77,8 +77,8 @@
         &__info {
           flex: 1;
           display: flex;
+          flex-direction: column-reverse;
           justify-content: space-between;
-          align-items: center;
           margin: 0 10px;
         }
 
@@ -94,8 +94,9 @@
         }
 
         &__title {
-          word-break: break-all;
+          word-break: break-word;
           flex: 1;
+          text-align: justify;
 
           abbr {
             border: none;
@@ -139,15 +140,17 @@
         }
 
         &__label {
-          padding-right: 3px;
+          text-align: left;
           color: $story-label-color;
           text-decoration: none;
+          font-style: normal;
+          margin-right: 5px;
         }
 
         &__labels {
           color: $story-labels-color;
           font-size: 84%;
-          margin: 0;
+          margin-top: 1px;
         }
 
         &__btn {


### PR DESCRIPTION
Small adjustment made to collapsed stories on central v2. Now the labels are displayed underneath the title. Here's how it looked before: 
![antes](https://user-images.githubusercontent.com/33486409/52069890-cbf16e80-2566-11e9-9383-f5e656df1bf5.png)

And how it looks now: 
![depois](https://user-images.githubusercontent.com/33486409/52069708-6e5d2200-2566-11e9-9f5e-4f7a1260a5e8.png)
