### PR TITLE
Fixed task checkboxes and scrolling on project in v2

### DIFF
--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -21,6 +21,7 @@ body {
 
 .board {
   background-color: $darkgrey-10;
+  height: auto;
 }
 
 .content-wrapper {

--- a/app/assets/stylesheets/new_board/_column.scss
+++ b/app/assets/stylesheets/new_board/_column.scss
@@ -2,9 +2,14 @@
 .Column {
   background-color: $darkgrey-11;
   flex: 1;
-  height: 100%;
+  height: auto;
+  min-height: 100vh;
   margin-left: 1px;
   margin-right: 1px;
+
+  &__body {
+    padding-bottom: 80px;
+  }
 
   &__header {
     display: flex;

--- a/app/assets/stylesheets/new_board/_project_board.scss
+++ b/app/assets/stylesheets/new_board/_project_board.scss
@@ -1,6 +1,6 @@
 .ProjectBoard {
   height: 100%;
   display: flex;
-  overflow: hidden;
+  overflow: inherit;
   padding-top: 2px;
 }

--- a/app/assets/stylesheets/new_board/_story.scss
+++ b/app/assets/stylesheets/new_board/_story.scss
@@ -32,6 +32,7 @@
 
     &__list-task {
       font-size: 12px;
+      position: relative;
     }
 
     &--collapsed {


### PR DESCRIPTION
Fixed the project page on v2 where scrolling wasn't possible (which is normally needed when expanding a story), and fixed small bug where the check boxes from the tasks in an expanded story were misplaced. Here's how it looks now:

![cm42-central-css](https://user-images.githubusercontent.com/33486409/52728049-b5530a80-2f9d-11e9-8663-b9985e152775.gif)
