### PR TITLE
Release v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] 2019-02-20
+
 ### Update
 - Front-End Dependencies
   - Webpack from 2.6.1 to 4.29.1
@@ -17,6 +19,7 @@
 ### Fixed
 - [ V2 ] Board style to permit scrolling
 - Fix alert favicon in production environment
+- Export projects with no stories
 
 ### Added
 - [ V2 ] Story:
@@ -395,7 +398,7 @@ and CVE-2018-14567)
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v2.1.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -429,3 +432,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [1.22.0]: https://github.com/Codeminer42/cm42-central/tree/v1.22.0
 [2.0.0]: https://github.com/Codeminer42/cm42-central/tree/v2.0.0
 [2.0.1]: https://github.com/Codeminer42/cm42-central/tree/v2.0.1
+[2.1.0]: https://github.com/Codeminer42/cm42-central/tree/v2.1.0


### PR DESCRIPTION
## [2.1.0] 2019-02-20

### Update
- Front-End Dependencies
  - Webpack from 2.6.1 to 4.29.1
  - React from 15.4.2 to 16.8.0
  - Redux from 3.7.2 to 4.0.1
  - Babel from 6.25.0 to 7.2.2
- Test Dependencies
  - Enzyme from 2.7.1 to 3.8.0
  - Jasmine from 2.5.1 to 3.3.0
  - Karma from 1.3.0 to 4.0.0
  - Sinon from 2.0.0 to 7.2.3

### Fixed
- [ V2 ] Board style to permit scrolling
- Fix alert favicon in production environment
- Export projects with no stories

### Added
- [ V2 ] Story:
  - Attachments:
    - With this change makes it necessary to set unsigned upload in cloudinary and set the ENV `CLOUDINARY_UPLOAD_PRESET`. For help you can see [this](https://cloudinary.com/documentation/upload_images#unsigned_upload) tutorial.