### PR TITLE
Feature/ update collapsed story

### DIFF
--- a/app/assets/javascripts/actions/story.js
+++ b/app/assets/javascripts/actions/story.js
@@ -47,6 +47,19 @@ export const setLoadingStory = (id) => ({
   id
 });
 
+export const updateCollapsedStory = (storyId, projectId, newAttributes) =>
+  (dispatch, getState, { Story }) => {
+    const { stories } = getState();
+    const story = stories.find((story) => story.id === storyId);
+
+    const newStory = { ...story, ...newAttributes };
+
+    return Story.update(newStory, projectId)
+      .then((story) => {
+        dispatch(updateStorySuccess(story));
+      });
+  }
+
 export const saveStory = (storyId, projectId, options) =>
   (dispatch, getState, { Story }) => {
     const { stories } = getState();

--- a/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryEstimateButton.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryEstimateButton.js
@@ -2,12 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 
-export const CollapsedStoryEstimateButton = (props) => (
+export const CollapsedStoryEstimateButton = ({ project, onUpdate }) => (
   <div className="Story__estimate-box">
     {
-      props.project.pointValues.map((value, index) => (
-        <span className="Story__estimate" key={`estimate-${value}`} data-value={value}>
-          { value }
+      project.pointValues.map((value) => (
+        <span className="Story__estimate"
+          key={`estimate-${value}`}
+          data-value={value}
+          onClick={() => onUpdate(value)}
+        >
+          {value}
         </span>
       ))
     }

--- a/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateActions.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateActions.js
@@ -15,21 +15,30 @@ const StateAction = {
   unstarted: ["start"]
 };
 
-const CollapsedStoryStateActions = ({ story }) => (
-  <div className='Story__actions'> 
-    {
-      isStoryNotEstimated(story.storyType, story.estimate) ?
-        <CollapsedStoryEstimateButton />
-        : StoryActionFor(story.state).map((stateAction) =>
-          <CollapsedStoryStateButton action={stateAction} key={stateAction} />
-        )
-    }
-  </div>
-);
+class CollapsedStoryStateActions extends React.Component {
+  disableToggle(event) {
+    event.stopPropagation();
+  }
+
+  render() {
+    const { story, onUpdate } = this.props;
+
+    return (
+      <div className='Story__actions' onClick={this.disableToggle}>
+        {
+          isStoryNotEstimated(story.storyType, story.estimate) ?
+            <CollapsedStoryEstimateButton onUpdate={((estimate) => onUpdate({ estimate }))} />
+            : StoryActionFor(story.state).map((stateAction) =>
+              <CollapsedStoryStateButton action={stateAction} key={stateAction} />
+            )
+        }
+      </div>
+    );
+  }
+};
 
 CollapsedStoryStateActions.propTypes = {
   story: PropTypes.object.isRequired
 };
-
 
 export default CollapsedStoryStateActions;

--- a/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateActions.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateActions.js
@@ -2,22 +2,43 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CollapsedStoryEstimateButton from './CollapsedStoryEstimateButton';
 import CollapsedStoryStateButton from './CollapsedStoryStateButton';
-import { isStoryNotEstimated } from '../../../models/beta/story';
+import { isStoryNotEstimated, getNextState, storyTransitions } from '../../../models/beta/story';
+import { status } from '../../../libs/beta/constants';
 
 const StoryActionFor = (state) => StateAction[state] || StateAction.unstarted;
 
 const StateAction = {
-  started: ["finish"],
-  finished: ["deliver"],
-  delivered: ["accept", "reject"],
-  rejected: ["restart"],
-  accepted: [],
-  unstarted: ["start"]
+  [status.STARTED]  : ["finish"],
+  [status.FINISHED] : ["deliver"],
+  [status.DELIVERED]: ["accept", "reject"],
+  [status.REJECTED] : ["restart"],
+  [status.ACCEPTED] : [],
+  [status.UNSTARTED]: ["start"]
 };
 
 class CollapsedStoryStateActions extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.confirmTransition = this.confirmTransition.bind(this);
+  }
+
   disableToggle(event) {
     event.stopPropagation();
+  }
+
+  confirmTransition(action, update) {
+    if (this.needConfirmation(action) && !window.confirm(
+      I18n.t('story.definitive_sure', { action })
+    )) {
+      return;
+    }
+
+    update();
+  }
+
+  needConfirmation(action) {
+    return action === storyTransitions.ACCEPT || action === storyTransitions.REJECT;
   }
 
   render() {
@@ -27,9 +48,19 @@ class CollapsedStoryStateActions extends React.Component {
       <div className='Story__actions' onClick={this.disableToggle}>
         {
           isStoryNotEstimated(story.storyType, story.estimate) ?
-            <CollapsedStoryEstimateButton onUpdate={((estimate) => onUpdate({ estimate }))} />
+            <CollapsedStoryEstimateButton
+              onUpdate={((estimate) => onUpdate({ estimate }))}
+            />
             : StoryActionFor(story.state).map((stateAction) =>
-              <CollapsedStoryStateButton action={stateAction} key={stateAction} />
+              <CollapsedStoryStateButton
+                action={stateAction}
+                key={stateAction}
+                onUpdate={() => {
+                  this.confirmTransition(stateAction, () => {
+                    onUpdate({ state: getNextState(story.state, stateAction) })
+                  })
+                }}
+              />
             )
         }
       </div>

--- a/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateButton.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateButton.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types';
 
-const CollapsedStoryStateButton = ({ action }) => (
-  <button type="button" className={`Story__btn Story__btn--${action}`}>
-    { I18n.t(`story.events.${action}`) }
+const CollapsedStoryStateButton = ({ action, onUpdate }) => (
+  <button type="button"
+    className={`Story__btn Story__btn--${action}`}
+    onClick={onUpdate}
+  >
+    {I18n.t(`story.events.${action}`)}
   </button>
 );
 

--- a/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateButton.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/CollapsedStoryStateButton.js
@@ -11,7 +11,8 @@ const CollapsedStoryStateButton = ({ action, onUpdate }) => (
 );
 
 CollapsedStoryStateButton.propTypes = {
-  action: PropTypes.string.isRequired
+  action: PropTypes.string.isRequired,
+  onUpdate: PropTypes.func.isRequired
 };
 
 export default CollapsedStoryStateButton;

--- a/app/assets/javascripts/components/story/CollapsedStory/index.js
+++ b/app/assets/javascripts/components/story/CollapsedStory/index.js
@@ -8,9 +8,10 @@ import CollapsedStoryStateActions from './CollapsedStoryStateActions';
 import CollapsedStoryInfo from './CollapsedStoryInfo';
 import StoryIcon from '../StoryIcon';
 import * as StoryModel from '../../../models/beta/story';
+import { updateCollapsedStory } from '../../../actions/story';
+import { connect } from 'react-redux';
 
 const classNameStory = (storyType, estimate) => {
-
   const isStoryNotEstimated = StoryModel.isStoryNotEstimated(storyType, estimate);
   const isRelease = StoryModel.isRelease(storyType);
 
@@ -22,8 +23,8 @@ const classNameStory = (storyType, estimate) => {
 };
 
 export const CollapsedStory = (props) => {
-  const { onToggle, story } = props;
-  
+  const { onToggle, story, updateCollapsedStory, project } = props;
+
   return (
     <div
       className={`Story Story--collapsed ${classNameStory(story.storyType, story.estimate)}`}
@@ -39,7 +40,10 @@ export const CollapsedStory = (props) => {
 
       <CollapsedStoryInfo story={story} />
 
-      <CollapsedStoryStateActions story={story} />
+      <CollapsedStoryStateActions story={story}
+        onUpdate={(newAttributes) =>
+          updateCollapsedStory(story.id, project.id, newAttributes)}
+      />
     </div>
   );
 };
@@ -48,4 +52,7 @@ CollapsedStory.propTypes = {
   story: PropTypes.object.isRequired
 };
 
-export default CollapsedStory;
+export default connect(
+  ({ project }) => ({ project }),
+  { updateCollapsedStory }
+)(CollapsedStory);

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
@@ -98,7 +98,7 @@ class ExpandedStoryAttachments extends React.Component {
   }
 }
 
-ExpandedStoryAttachments.PropTypes = {
+ExpandedStoryAttachments.propTypes = {
   story: PropTypes.object.isRequired,
   onDelete: PropTypes.func.isRequired,
   onAdd: PropTypes.func.isRequired

--- a/app/assets/javascripts/components/story/attachment/AttachmentList.js
+++ b/app/assets/javascripts/components/story/attachment/AttachmentList.js
@@ -27,7 +27,7 @@ const AttachmentsList = ({ files, onDelete }) =>
     }
   </div>
 
-AttachmentsList.PropTypes = {
+AttachmentsList.propTypes = {
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
   onDelete: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -251,3 +251,49 @@ const emptyStory = {
   documents: [],
   tasks: [],
 };
+export const serialize = (story) => ({
+  ...story,
+  labels: Label.joinLabels(story.labels)
+});
+
+export const storyTransitions = {
+  START  : 'start',
+  FINISH : 'finish',
+  DELIVER: 'deliver',
+  ACCEPT : 'accept',
+  REJECT : 'reject',
+  RESTART: 'restart'
+};
+
+const stateTransitions = {
+  [status.UNSCHEDULED]: {
+    [storyTransitions.START]: status.STARTED
+  },
+  [status.UNSTARTED]: {
+    [storyTransitions.START]: status.STARTED
+  },
+  [status.STARTED]: {
+    [storyTransitions.FINISH]: status.FINISHED
+  },
+  [status.FINISHED]: {
+    [storyTransitions.DELIVER]: status.DELIVERED
+  },
+  [status.DELIVERED]: {
+    [storyTransitions.ACCEPT]: status.ACCEPTED,
+    [storyTransitions.REJECT]: status.REJECTED
+  },
+  [status.REJECTED]: {
+    [storyTransitions.RESTART]: status.STARTED
+  },
+  [status.ACCEPTED] : {}
+};
+
+export const getNextState = (currentState, transition) => {
+  const nextState = stateTransitions[currentState][transition];
+
+  if(nextState) {
+    return nextState;
+  }
+
+  return currentState;
+}

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -251,10 +251,6 @@ const emptyStory = {
   documents: [],
   tasks: [],
 };
-export const serialize = (story) => ({
-  ...story,
-  labels: Label.joinLabels(story.labels)
-});
 
 export const storyTransitions = {
   START  : 'start',

--- a/spec/javascripts/actions/story_spec.js
+++ b/spec/javascripts/actions/story_spec.js
@@ -140,6 +140,34 @@ describe('saveStory', () => {
   });
 });
 
+describe('updateCollapsedStory', () => {
+  const projectId = 42;
+
+  it('calls Story.update with newStory and projectId', (done) => {
+    const story = storyFactory({ storyType: 'feature', estimate: 1 });
+    const newAttributes = { estimate: 4 };
+
+    const editedStory = { ...story, ...newAttributes };
+
+    const FakeStory = {
+      update: sinon.stub().resolves(story)
+    };
+
+    const fakeDispatch = sinon.stub().resolves({});
+
+    const fakeGetState = sinon.stub();
+    fakeGetState.returns({ stories: [story] });
+
+    Story.updateCollapsedStory(editedStory.id, projectId, newAttributes)
+      (fakeDispatch, fakeGetState, { Story: FakeStory }).then(() => {
+        expect(FakeStory.update).toHaveBeenCalledWith(editedStory, projectId);
+
+        done();
+      });
+  });
+});
+
+
 describe('deleteStory', () => {
   const storyId = 420;
   const projectId = 42;

--- a/spec/javascripts/components/story/collapsed_story/collapsed_story_spec.js
+++ b/spec/javascripts/components/story/collapsed_story/collapsed_story_spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import CollapsedStory from 'components/story/CollapsedStory/index';
+import { CollapsedStory } from 'components/story/CollapsedStory/index';
 import storyFactory from '../../../support/factories/storyFactory';
 
 describe('<CollapsedStory />', () => {

--- a/spec/javascripts/components/story/collapsed_story/collapsed_story_state_button_spec.js
+++ b/spec/javascripts/components/story/collapsed_story/collapsed_story_state_button_spec.js
@@ -11,4 +11,17 @@ describe('<CollapsedStoryStateButton />', () => {
     expect(wrapper.text()).toEqual(I18n.translate('story.events.' + props.action));
     expect(wrapper).toHaveClassName(`Story__btn Story__btn--${props.action}`);
   });
+
+  it('calls onUpdate on click', () => {
+    const action = 'start';
+    const onUpdate = sinon.stub();
+
+    const wrapper = shallow(<CollapsedStoryStateButton
+      action={action}
+      onUpdate={onUpdate}
+    />);
+
+    wrapper.find('button').simulate('click');
+    expect(onUpdate).toHaveBeenCalled();
+  })
 });

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -511,4 +511,128 @@ describe('Story model', function () {
       expect(newStoryArray).toEqual(expectedArray);
     });
   });
+  describe('getNextState', () => {
+    describe('when the state is unscheduled', () => {
+      const state = 'unscheduled';
+
+      it('returns started when transition is start', () => {
+        const transition = 'start';
+        const expectedState = 'started'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+        const expectedState = 'unscheduled'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+    });
+
+    describe('when the state is unstarted', () => {
+      const state = 'unstarted';
+
+      it('returns started when transition is start', () => {
+        const transition = 'start';
+        const expectedState = 'started'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+        const expectedState = 'unstarted'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+    });
+
+    describe('when the state is started', () => {
+      const state = 'started';
+
+      it('returns finished when transition is finish', () => {
+        const transition = 'finish';
+        const expectedState = 'finished'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+        const expectedState = 'started'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+    });
+
+    describe('when the state is finished', () => {
+      const state = 'finished';
+
+      it('returns delivered when transition is deliver', () => {
+        const transition = 'deliver';
+        const expectedState = 'delivered'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+        const expectedState = 'finished'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+    });
+
+    describe('when the state is delivered', () => {
+      const state = 'delivered';
+
+      it('returns accepted when transition is accept', () => {
+        const transition = 'accept';
+        const expectedState = 'accepted'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns rejected when transition is reject', () => {
+        const transition = 'reject';
+        const expectedState = 'rejected'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+
+        expect(Story.getNextState(state, transition)).toBe(state);
+      });
+    });
+
+    describe('when the state is rejected', () => {
+      const state = 'rejected';
+
+      it('returns started when transition is restart', () => {
+        const transition = 'restart';
+        const expectedState = 'started'
+
+        expect(Story.getNextState(state, transition)).toBe(expectedState);
+      });
+
+      it('returns the same state when transition is invalid', () => {
+        const transition = 'invalidTransition';
+
+        expect(Story.getNextState(state, transition)).toBe(state);
+      });
+    });
+
+    describe("when the state is accepted", () => {
+      const state = 'accepted';
+
+      it('not change state', () => {
+        const transition = 'any';
+
+        expect(Story.getNextState(state, transition)).toBe(state);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Now we can change the estimation and state of a closed story.

stories:
 - [#23440](https://central.cm42.io/projects/central-board-v2#story-23440) (Estimate)
 - [#23481](https://central.cm42.io/projects/central-board-v2#story-23481) (State)

It closes [#512](https://github.com/Codeminer42/cm42-central/pull/512).

![cm42 central 11](https://user-images.githubusercontent.com/15300776/53435777-5bf4cd80-39d8-11e9-8bec-a976098d1483.gif)
