### PR TITLE
Fix/remove redundant task actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+ - [ V2 ] Remove redundant switch cases from the stories reducer.
+
 ## [2.2.0] 2019-03-15
 
 ### Added

--- a/app/assets/javascripts/reducers/stories.js
+++ b/app/assets/javascripts/reducers/stories.js
@@ -75,21 +75,6 @@ const storiesReducer = (state = initialState, action) => {
         updateIfSameId(action.storyId, (story) => {
           return Note.deleteNote(story, action.noteId)
         }));
-    case actionTypes.ADD_TASK:
-      return state.map(
-        updateIfSameId(action.story.id, (story) => {
-          return Task.addTask(story, action.task);
-        }));
-    case actionTypes.REMOVE_TASK:
-      return state.map(
-        updateIfSameId(action.story.id, (story) => {
-          return Task.deleteTask(action.task, story);
-        }));
-    case actionTypes.UPDATE_TASK:
-      return state.map(
-        updateIfSameId(action.story.id, (story) => {
-          return Task.updateTask(story, action.task);
-        }));
     case actionTypes.ADD_LABEL:
       return state.map(
         updateIfSameId(action.storyId, (story) => ({


### PR DESCRIPTION
Simply removed some redundant switch cases from the stories reducer. [#23746](https://central.cm42.io/projects/central-board-v2#story-23746)