### PR TITLE
Feature/disable accepted story fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [ V2 ] Story:
   - Stories of release type
   - Option to Clone Stories
+  - Disable fields when story is read-only
 
 ## [2.2.0] 2019-03-15
 

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
@@ -56,42 +56,47 @@ class ExpandedStoryAttachments extends React.Component {
   }
 
   render() {
-    const { story, onDelete } = this.props;
+    const { story, onDelete, disabled } = this.props;
+
+    if(disabled && !story.documents.length) return null
 
     return (
       <ExpandedStorySection
         title={I18n.t('story.attachments')}
         identifier="attachments"
       >
-        <Dropzone
-          onDrop={this.onFileDrop}
-          accept={acceptedMimeTypes()}
-          disabled={this.state.loading}
-          multiple={false}
-        >
-          {({ getRootProps, getInputProps, isDragActive, isDragReject }) => {
-            const className = this.dropzoneClassName({ isDragActive, isDragReject })
+        {
+          !disabled && 
+            <Dropzone
+              onDrop={this.onFileDrop}
+              accept={acceptedMimeTypes()}
+              disabled={this.state.loading}
+              multiple={false}
+            >
+              {({ getRootProps, getInputProps, isDragActive, isDragReject }) => {
+                const className = this.dropzoneClassName({ isDragActive, isDragReject })
 
-            return (
-              <div
-                {...getRootProps()}
-                className={`btn btn-success attachments-dropzone ${className}`}
-              >
-                <input {...getInputProps()} />
-                <i className="mi md-20">cloud_upload</i>
-                <div>
-                  {!isDragReject ?
-                    I18n.t('upload_new_file') :
-                    I18n.t('reject_new_file')}
-                </div>
-              </div>
-            )
-          }}
-        </Dropzone>
-
+                return (
+                  <div
+                    {...getRootProps()}
+                    className={`btn btn-success attachments-dropzone ${className}`}
+                  >
+                    <input {...getInputProps()} />
+                    <i className="mi md-20">cloud_upload</i>
+                    <div>
+                      {!isDragReject ?
+                        I18n.t('upload_new_file') :
+                        I18n.t('reject_new_file')}
+                    </div>
+                  </div>
+                )
+              }}
+            </Dropzone>
+        }
         <AttachmentsList
           files={story._editing.documents}
           onDelete={onDelete}
+          disabled={disabled}
         />
       </ExpandedStorySection>
     );
@@ -101,7 +106,8 @@ class ExpandedStoryAttachments extends React.Component {
 ExpandedStoryAttachments.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onAdd: PropTypes.func.isRequired
+  onAdd: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryAttachments;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAttachments.js
@@ -58,7 +58,7 @@ class ExpandedStoryAttachments extends React.Component {
   render() {
     const { story, onDelete, disabled } = this.props;
 
-    if(disabled && !story.documents.length) return null
+    if (disabled && !story.documents.length) return null
 
     return (
       <ExpandedStorySection
@@ -66,7 +66,7 @@ class ExpandedStoryAttachments extends React.Component {
         identifier="attachments"
       >
         {
-          !disabled && 
+          !disabled && (
             <Dropzone
               onDrop={this.onFileDrop}
               accept={acceptedMimeTypes()}
@@ -92,6 +92,7 @@ class ExpandedStoryAttachments extends React.Component {
                 )
               }}
             </Dropzone>
+          )
         }
         <AttachmentsList
           files={story._editing.documents}

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDefault/index.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDefault/index.js
@@ -24,7 +24,7 @@ import ExpandedStoryOwnedBy from '../ExpandedStoryOwnedBy';
 export const ExpandedStoryDefault = ({
   titleRef,
   story, users, project,
-  onEdit, onClone,
+  onEdit, onClone, disabled,
   addLabel, removeLabel,
   createNote, deleteNote,
   createTask, deleteTask, toggleTask,
@@ -45,6 +45,7 @@ export const ExpandedStoryDefault = ({
       story={story}
       titleRef={titleRef}
       onEdit={(title) => onEdit({ title })}
+      disabled={disabled}
     />
 
     <div className="Story__flex">
@@ -52,29 +53,34 @@ export const ExpandedStoryDefault = ({
         story={story}
         onEdit={(estimate) => onEdit({ estimate })}
         project={project}
+        disabled={disabled}
       />
 
       <ExpandedStoryType
         story={story}
         onEdit={(storyType) => onEdit({ storyType })}
+        disabled={disabled}
       />
     </div>
 
     <ExpandedStoryState
       story={story}
       onEdit={(state) => onEdit({ state })}
+      disabled={disabled}
     />
 
     <ExpandedStoryRequestedBy
       story={story}
       users={users}
       onEdit={(requestedById) => onEdit({ requestedById })}
+      disabled={disabled}
     />
 
     <ExpandedStoryOwnedBy
       story={story}
       users={users}
       onEdit={(ownedById) => onEdit({ ownedById })}
+      disabled={disabled}
     />
 
     <ExpandedStoryLabels
@@ -83,11 +89,13 @@ export const ExpandedStoryDefault = ({
       projectLabels={project.labels}
       onRemoveLabel={(labelName) => removeLabel(story.id, labelName)}
       onEdit={(labels) => onEdit({ labels })}
+      disabled={disabled}
     />
 
     <ExpandedStoryDescription
       story={story}
       onEdit={(description) => onEdit({ description })}
+      disabled={disabled}
     />
 
     {
@@ -98,6 +106,7 @@ export const ExpandedStoryDefault = ({
             onToggle={(task, status) => toggleTask(project.id, story, task, status)}
             onDelete={(taskId) => deleteTask(project.id, story.id, taskId)}
             onSave={(task) => createTask(project.id, story.id, task)}
+            disabled={disabled}
           />
 
           <ExpandedStoryAttachments
@@ -106,12 +115,15 @@ export const ExpandedStoryDefault = ({
             startLoading={() => setLoadingStory(story.id)}
             onAdd={(attachment) => addAttachment(story.id, project.id, attachment)}
             onDelete={(documentId) => removeAttachment(story.id, documentId)}
+            disabled={disabled}
           />
+          
           <ExpandedStoryNotes
             story={story}
             projectId={project.id}
             onDelete={(noteId) => deleteNote(project.id, story.id, noteId)}
             onCreate={(note) => createNote(project.id, story.id, { note })}
+            disabled={disabled}
           />
         </Fragment>
         : null
@@ -134,7 +146,8 @@ ExpandedStoryDefault.propTypes = {
   removeAttachment: PropTypes.func.isRequired,
   setLoadingStory: PropTypes.func.isRequired,
   storyFailure: PropTypes.func.isRequired,
-  onClone: PropTypes.func.isRequired
+  onClone: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = ({ users }) => ({ users });

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDescription.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDescription.js
@@ -36,19 +36,22 @@ class ExpandedStoryDescription extends React.Component {
   };
 
   descriptionTextArea(description) {
-    const { onEdit } = this.props;
+    const { onEdit, disabled } = this.props;
 
     return (
       <textarea
         className="form-control input-sm edit-description-text"
         onChange={(event) => onEdit(event.target.value)}
+        readOnly={disabled}
         value={description}
       />
     );
   };
 
   render() {
-    const { story } = this.props;
+    const { story, disabled } = this.props;
+
+    if(disabled && !story.description) return null
 
     return (
       <ExpandedStorySection
@@ -75,7 +78,8 @@ class ExpandedStoryDescription extends React.Component {
 
 ExpandedStoryDescription.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryDescription;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryEstimate.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryEstimate.js
@@ -4,7 +4,7 @@ import { isFeature, editingStoryPropTypesShape } from '../../../models/beta/stor
 import { projectPropTypesShape } from '../../../models/beta/project';
 import ExpandedStorySection from './ExpandedStorySection';
 
-const ExpandedStoryEstimate = ({ project, story, onEdit }) =>
+const ExpandedStoryEstimate = ({ project, story, onEdit, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.estimate')}
   >
@@ -12,7 +12,7 @@ const ExpandedStoryEstimate = ({ project, story, onEdit }) =>
       value={story._editing.estimate}
       className="form-control input-sm"
       onChange={(event) => onEdit(parseInt(event.target.value))}
-      disabled={!isFeature(story._editing)}
+      disabled={disabled || !isFeature(story._editing)}
     >
       <option value=''>
         {I18n.t('story.no_estimate')}
@@ -30,7 +30,8 @@ const ExpandedStoryEstimate = ({ project, story, onEdit }) =>
 ExpandedStoryEstimate.propTypes = {
   project: projectPropTypesShape.isRequired,
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryEstimate;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryLabels.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryLabels.js
@@ -13,8 +13,10 @@ class ExpandedStoryLabels extends React.Component {
   }
 
   handleDelete(index) {
-    const { story, onRemoveLabel } = this.props;
+    const { story, onRemoveLabel, disabled } = this.props;
     const { labels } = story._editing;
+
+    if(disabled) return;
 
     const label = labels.find(
       (label, labelIndex) => labelIndex === index
@@ -30,8 +32,10 @@ class ExpandedStoryLabels extends React.Component {
   }
 
   render() {
-    const { projectLabels, story } = this.props;
+    const { projectLabels, story, disabled } = this.props;
     const { labels } = story._editing;
+
+    if(disabled && !story.labels.length) return null
 
     return (
       <ExpandedStorySection
@@ -42,8 +46,9 @@ class ExpandedStoryLabels extends React.Component {
           handleDelete={this.handleDelete}
           suggestions={projectLabels}
           handleAddition={this.handleAddition}
-          allowNew={true}
-          placeholder={I18n.t('add new label')}
+          allowNew={!disabled}
+          inputAttributes={{readOnly: disabled}}
+          placeholder={disabled ? "" : I18n.t('add new label')}
           allowBackspace={false}
           addOnBlur={true}
           delimiterChars={[',', ' ']}
@@ -59,7 +64,8 @@ ExpandedStoryLabels.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onAddLabel: PropTypes.func.isRequired,
   onRemoveLabel: PropTypes.func.isRequired,
-  projectLabels: PropTypes.arrayOf(PropTypes.object).isRequired
+  projectLabels: PropTypes.arrayOf(PropTypes.object).isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryLabels;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryNotes.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryNotes.js
@@ -53,7 +53,9 @@ class ExpandedStoryNotes extends React.Component {
   }
 
   render() {
-    const { story, onDelete } = this.props;
+    const { story, onDelete, disabled } = this.props;
+
+    if(disabled && !story.notes.length) return null
 
     return (
       <ExpandedStorySection
@@ -61,11 +63,12 @@ class ExpandedStoryNotes extends React.Component {
         identifier="notes"
       >
         <NotesList
-          onDelete={onDelete}
           notes={story.notes}
+          onDelete={onDelete}
+          disabled={disabled}
         />
 
-        {this.notesForm()}
+        {!disabled && this.notesForm()}
       </ExpandedStorySection>
     );
   }
@@ -74,7 +77,8 @@ class ExpandedStoryNotes extends React.Component {
 ExpandedStoryNotes.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onCreate: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryNotes;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryOwnedBy.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryOwnedBy.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SelectUser from '../select_user/SelectUser';
-import { editingStoryPropTypesShape } from '../../../models/beta/story';
+import { canEdit, editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
-const ExpandedStoryOwnedBy = ({ users, story, onEdit }) =>
+const ExpandedStoryOwnedBy = ({ users, story, onEdit, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.owned_by')}
   >
@@ -12,13 +12,15 @@ const ExpandedStoryOwnedBy = ({ users, story, onEdit }) =>
       users={users}
       selectedUserId={story._editing.ownedById}
       onEdit={onEdit}
+      disabled={disabled}
     />
   </ExpandedStorySection>
 
 ExpandedStoryOwnedBy.propTypes = {
   users: PropTypes.array.isRequired,
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default ExpandedStoryOwnedBy;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryOwnedBy.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryOwnedBy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SelectUser from '../select_user/SelectUser';
-import { canEdit, editingStoryPropTypesShape } from '../../../models/beta/story';
+import { editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
 const ExpandedStoryOwnedBy = ({ users, story, onEdit, disabled }) =>

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRelease/ExpandedStoryReleaseDate.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRelease/ExpandedStoryReleaseDate.js
@@ -5,7 +5,7 @@ import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import { editingStoryPropTypesShape } from '../../../../models/beta/story';
 
-const ExpandedStoryReleaseDate = ({ onEdit, story }) => {
+const ExpandedStoryReleaseDate = ({ onEdit, story, disabled }) => {
   const releaseDate = moment(story._editing.releaseDate, ["YYYY-MM-DD"]);
   const validReleaseDate = releaseDate.isValid() ? releaseDate : null;
 
@@ -22,6 +22,7 @@ const ExpandedStoryReleaseDate = ({ onEdit, story }) => {
         onChange={(releaseDate) =>
           onEdit(releaseDate.format())
         }
+        disabled={disabled}
       />
     </ExpandedStorySection>
   )
@@ -29,7 +30,8 @@ const ExpandedStoryReleaseDate = ({ onEdit, story }) => {
 
 ExpandedStoryReleaseDate.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryReleaseDate;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRelease/index.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRelease/index.js
@@ -11,7 +11,8 @@ const ExpandedStoryRelease = ({
   story,
   titleRef,
   onEdit,
-  onClone
+  onClone,
+  disabled
 }) =>
   <Fragment>
     {
@@ -27,28 +28,33 @@ const ExpandedStoryRelease = ({
       story={story}
       titleRef={titleRef}
       onEdit={(title) => onEdit({ title })}
+      disabled={disabled}
     />
 
     <ExpandedStoryType
       story={story}
       onEdit={(storyType) => onEdit({ storyType })}
+      disabled={disabled}
     />
 
     <ExpandedStoryReleaseDate
       story={story}
       onEdit={(releaseDate) => onEdit({ releaseDate })}
+      disabled={disabled}
     />
 
     <ExpandedStoryDescription
       story={story}
       onEdit={(description) => onEdit({ description })}
+      disabled={disabled}
     />
   </Fragment>
 
 ExpandedStoryRelease.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onEdit: PropTypes.func.isRequired,
-  onClone: PropTypes.func.isRequired
+  onClone: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryRelease;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRequestedBy.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryRequestedBy.js
@@ -4,7 +4,7 @@ import SelectUser from '../select_user/SelectUser';
 import { editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
-const ExpandedStoryRequestedBy = ({ users, story, onEdit }) =>
+const ExpandedStoryRequestedBy = ({ users, story, onEdit, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.requested_by')}
   >
@@ -12,13 +12,15 @@ const ExpandedStoryRequestedBy = ({ users, story, onEdit }) =>
       users={users}
       selectedUserId={story._editing.requestedById}
       onEdit={onEdit}
+      disabled={disabled}
     />
   </ExpandedStorySection>
 
 ExpandedStoryRequestedBy.propTypes = {
   users: PropTypes.array.isRequired,
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default ExpandedStoryRequestedBy;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryState.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryState.js
@@ -4,7 +4,7 @@ import * as Story from '../../../models/beta/story';
 import { editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
-const ExpandedStoryState = ({ story, onEdit }) =>
+const ExpandedStoryState = ({ story, onEdit, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.state')}
   >
@@ -12,6 +12,7 @@ const ExpandedStoryState = ({ story, onEdit }) =>
       value={story._editing.state}
       className="form-control input-sm"
       onChange={(event) => onEdit(event.target.value)}
+      disabled={disabled}
     >
       {
         Story.states.map((state) => (
@@ -25,7 +26,8 @@ const ExpandedStoryState = ({ story, onEdit }) =>
 
 ExpandedStoryState.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryState;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
@@ -37,7 +37,7 @@ class ExpandedStoryTask extends Component {
   render() {
     const { story, onToggle, onDelete, disabled } = this.props;
 
-    if (!story.tasks.length && disabled) return null;
+    if (disabled && !story.tasks.length) return null;
 
     return (
       <ExpandedStorySection
@@ -54,7 +54,7 @@ class ExpandedStoryTask extends Component {
         </div>
 
         {
-          !disabled &&
+          !disabled && (
             <div className="task-form">
               <input
                 value={this.state.task}
@@ -70,6 +70,7 @@ class ExpandedStoryTask extends Component {
                 {I18n.t('add task')}
               </button>
             </div>
+          )
         }
       </ExpandedStorySection>
     );

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTask.js
@@ -35,7 +35,9 @@ class ExpandedStoryTask extends Component {
   }
 
   render() {
-    const { story, onToggle, onDelete } = this.props;
+    const { story, onToggle, onDelete, disabled } = this.props;
+
+    if (!story.tasks.length && disabled) return null;
 
     return (
       <ExpandedStorySection
@@ -47,24 +49,28 @@ class ExpandedStoryTask extends Component {
             tasks={story.tasks}
             onDelete={onDelete}
             onToggle={onToggle}
+            disabled={disabled}
           />
         </div>
 
-        <div className="task-form">
-          <input
-            value={this.state.task}
-            className="form-control input-sm"
-            onChange={this.onInputChange}
-          />
-          <button
-            type='submit'
-            className='add-task-button'
-            onClick={this.onHandleSubmit}
-            disabled={this.hasAnEmptyValue()}
-          >
-            {I18n.t('add task')}
-          </button>
-        </div>
+        {
+          !disabled &&
+            <div className="task-form">
+              <input
+                value={this.state.task}
+                className="form-control input-sm"
+                onChange={this.onInputChange}
+              />
+              <button
+                type='submit'
+                className='add-task-button'
+                onClick={this.onHandleSubmit}
+                disabled={this.hasAnEmptyValue()}
+              >
+                {I18n.t('add task')}
+              </button>
+            </div>
+        }
       </ExpandedStorySection>
     );
   }
@@ -74,7 +80,8 @@ ExpandedStoryTask.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onToggle: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired
+  onSave: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryTask;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTitle.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryTitle.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
-const ExpandedStoryTitle = ({ story, onEdit, titleRef }) =>
+const ExpandedStoryTitle = ({ story, onEdit, titleRef, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.title')}
   >
@@ -11,6 +11,7 @@ const ExpandedStoryTitle = ({ story, onEdit, titleRef }) =>
       value={story._editing.title}
       ref={titleRef}
       className="form-control input-sm"
+      readOnly={disabled}
       onChange={(event) => onEdit(event.target.value)}
     />
   </ExpandedStorySection>
@@ -18,6 +19,7 @@ const ExpandedStoryTitle = ({ story, onEdit, titleRef }) =>
 ExpandedStoryTitle.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
   onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryTitle

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryType.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryType.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { types, editingStoryPropTypesShape } from '../../../models/beta/story';
 import ExpandedStorySection from './ExpandedStorySection';
 
-export const ExpandedStoryType = ({ story, onEdit }) =>
+export const ExpandedStoryType = ({ story, onEdit, disabled }) =>
   <ExpandedStorySection
     title={I18n.t('activerecord.attributes.story.story_type')}
   >
@@ -11,6 +11,7 @@ export const ExpandedStoryType = ({ story, onEdit }) =>
       value={story._editing.storyType}
       className="form-control input-sm"
       onChange={(event) => onEdit(event.target.value)}
+      disabled={disabled}
     >
       {
         types.map((value) => (
@@ -24,7 +25,8 @@ export const ExpandedStoryType = ({ story, onEdit }) =>
 
 ExpandedStoryType.propTypes = {
   story: editingStoryPropTypesShape.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default ExpandedStoryType;

--- a/app/assets/javascripts/components/story/ExpandedStory/index.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/index.js
@@ -33,6 +33,7 @@ export class ExpandedStory extends React.Component {
     } = this.props;
 
     const loading = story._editing.loading ? "Story__enable-loading" : "";
+    const disabled = !Story.canEdit(story);
 
     return (
       <div
@@ -57,6 +58,7 @@ export class ExpandedStory extends React.Component {
               titleRef={this.titleRef}
               onEdit={(newAttributes) => editStory(story.id, newAttributes)}
               onClone={cloneStory}
+              disabled={disabled}
             />
             : <ExpandedStoryDefault
               story={story}
@@ -64,6 +66,7 @@ export class ExpandedStory extends React.Component {
               onEdit={(newAttributes) => editStory(story.id, newAttributes)}
               project={project}
               onClone={cloneStory}
+              disabled={disabled}
             />
         }
       </div >

--- a/app/assets/javascripts/components/story/attachment/AttachmentList.js
+++ b/app/assets/javascripts/components/story/attachment/AttachmentList.js
@@ -18,7 +18,7 @@ const AttachmentsList = ({ files, onDelete, disabled }) =>
             type={file.resourceType}
           >
             {
-              !disabled &&
+              !disabled && (
                 <button
                   onClick={() => onDelete(file.id)}
                   className="btn btn-danger btn-xs"
@@ -26,6 +26,7 @@ const AttachmentsList = ({ files, onDelete, disabled }) =>
                   <i className="mi md-18">delete</i>
                   {I18n.t('delete')}
                 </button>
+              )
             }
           </Attachment>
         )

--- a/app/assets/javascripts/components/story/attachment/AttachmentList.js
+++ b/app/assets/javascripts/components/story/attachment/AttachmentList.js
@@ -4,33 +4,39 @@ import Attachment from './Attachment';
 import * as AttachmentURL from '../../../models/beta/attachmentUrl';
 import { attachmentPropTypesShape } from '../../../models/beta/attachment';
 
-const AttachmentsList = ({ files, onDelete }) =>
+const AttachmentsList = ({ files, onDelete, disabled }) =>
   <Fragment>
     {
       files.map(file => {
         const link = AttachmentURL.getFileLink(file.resourceType, file.path);
-        return <Attachment
-          id={file.id}
-          key={file.publicId}
-          link={link}
-          publicId={file.publicId}
-          type={file.resourceType}
-        >
-          <button
-            onClick={() => onDelete(file.id)}
-            className="btn btn-danger btn-xs"
+        return (
+          <Attachment
+            id={file.id}
+            key={file.publicId}
+            link={link}
+            publicId={file.publicId}
+            type={file.resourceType}
           >
-            <i className="mi md-18">delete</i>
-            {I18n.t('delete')}
-          </button>
-        </Attachment>
+            {
+              !disabled &&
+                <button
+                  onClick={() => onDelete(file.id)}
+                  className="btn btn-danger btn-xs"
+                >
+                  <i className="mi md-18">delete</i>
+                  {I18n.t('delete')}
+                </button>
+            }
+          </Attachment>
+        )
       })
     }
   </Fragment>
 
 AttachmentsList.propTypes = {
   files: PropTypes.arrayOf(attachmentPropTypesShape.isRequired),
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default AttachmentsList;

--- a/app/assets/javascripts/components/story/note/Note.js
+++ b/app/assets/javascripts/components/story/note/Note.js
@@ -10,12 +10,13 @@ const Note = ({ note, onDelete, disabled }) => (
     <div className='markdown-wrapper__text-right'>
       {`${note.userName} - ${note.createdAt} `}
       {
-        !disabled &&
+        !disabled && (
           <span
             className='delete-note-button'
             onClick={onDelete}
             children={I18n.t('delete')}
           />
+        )
       }
     </div>
   </div>

--- a/app/assets/javascripts/components/story/note/Note.js
+++ b/app/assets/javascripts/components/story/note/Note.js
@@ -3,25 +3,28 @@ import Markdown from '../../Markdown';
 import PropTypes from 'prop-types';
 import { notePropTypesShape } from '../../../models/beta/note';
 
-const Note = ({ note, onDelete }) => (
+const Note = ({ note, onDelete, disabled }) => (
   <div className='markdown-wrapper'>
     <Markdown source={note.note} />
 
     <div className='markdown-wrapper__text-right'>
       {`${note.userName} - ${note.createdAt} `}
-      <span
-        className='delete-note-button'
-        onClick={onDelete}
-      >
-        {I18n.t('delete')}
-      </span>
+      {
+        !disabled &&
+          <span
+            className='delete-note-button'
+            onClick={onDelete}
+            children={I18n.t('delete')}
+          />
+      }
     </div>
   </div>
 );
 
 Note.propTypes = {
   note: notePropTypesShape.isRequired,
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default Note;

--- a/app/assets/javascripts/components/story/note/NotesList.js
+++ b/app/assets/javascripts/components/story/note/NotesList.js
@@ -3,7 +3,7 @@ import Note from './Note';
 import PropTypes from 'prop-types';
 import { notePropTypesShape } from '../../../models/beta/note';
 
-const NotesList = ({ notes, onDelete }) => (
+const NotesList = ({ notes, onDelete, disabled }) => (
   <Fragment>
     {
       notes.map(note => (
@@ -11,6 +11,7 @@ const NotesList = ({ notes, onDelete }) => (
           key={note.id}
           note={note}
           onDelete={() => onDelete(note.id)}
+          disabled={disabled}
         />
       ))
     }
@@ -19,7 +20,8 @@ const NotesList = ({ notes, onDelete }) => (
 
 NotesList.propTypes = {
   notes: PropTypes.arrayOf(notePropTypesShape.isRequired),
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default NotesList;

--- a/app/assets/javascripts/components/story/select_user/SelectUser.js
+++ b/app/assets/javascripts/components/story/select_user/SelectUser.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const SelectUser = ({ selectedUserId, onEdit, users }) => (
+const SelectUser = ({ selectedUserId, onEdit, disabled, users }) => (
   <select
     value={selectedUserId || ''}
     className="form-control input-sm"
     onChange={(event) => onEdit(event.target.value)}
+    disabled={disabled}
   >
     <option value=''>
       ----
@@ -32,7 +33,8 @@ SelectUser.propTypes = {
   users: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired
-  }))
+  })),
+  disabled: PropTypes.bool.isRequired
 };
 
 export default SelectUser;

--- a/app/assets/javascripts/components/story/task/Task.js
+++ b/app/assets/javascripts/components/story/task/Task.js
@@ -14,14 +14,14 @@ const Task = ({ task, onDelete, onToggle, disabled }) => (
       {task.name}
     </label>
     {
-      !disabled &&
+      !disabled && (
         <span
           title={I18n.t('delete')}
           className='delete-btn'
           onClick={onDelete}
-        >
-          { I18n.t('delete') }
-        </span>
+          children={I18n.t('delete')}
+        />
+      )
     }
   </div>
 );

--- a/app/assets/javascripts/components/story/task/Task.js
+++ b/app/assets/javascripts/components/story/task/Task.js
@@ -2,30 +2,35 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { taskPropTypesShape } from '../../../models/beta/task';
 
-const Task = ({ task, onDelete, onToggle }) => (
+const Task = ({ task, onDelete, onToggle, disabled }) => (
   <div className="task">
     <label>
       <input
         type='checkbox'
         defaultChecked={task.done}
         onClick={onToggle}
+        disabled={disabled}
       />
       {task.name}
     </label>
-    <span
-      title={I18n.t('delete')}
-      className='delete-btn'
-      onClick={onDelete}
-    >
-      { I18n.t('delete') }
-    </span>
+    {
+      !disabled &&
+        <span
+          title={I18n.t('delete')}
+          className='delete-btn'
+          onClick={onDelete}
+        >
+          { I18n.t('delete') }
+        </span>
+    }
   </div>
 );
 
 Task.propTypes = {
   task: taskPropTypesShape.isRequired,
   onToggle: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default Task;

--- a/app/assets/javascripts/components/story/task/TasksList.js
+++ b/app/assets/javascripts/components/story/task/TasksList.js
@@ -3,7 +3,7 @@ import Task from './Task'
 import PropTypes from 'prop-types';
 import { taskPropTypesShape } from '../../../models/beta/task';
 
-const TasksList = ({ tasks, onDelete, onToggle }) => (
+const TasksList = ({ tasks, onDelete, onToggle, disabled }) => (
   <Fragment>
     {
       tasks.map((task) => (
@@ -12,6 +12,7 @@ const TasksList = ({ tasks, onDelete, onToggle }) => (
           task={task}
           onDelete={() => onDelete(task.id)}
           onToggle={() => onToggle(task, { done: !task.done })}
+          disabled={disabled}
         />
       ))
     }
@@ -21,7 +22,8 @@ const TasksList = ({ tasks, onDelete, onToggle }) => (
 TasksList.propTypes = {
   tasks: PropTypes.arrayOf(taskPropTypesShape.isRequired),
   onDelete: PropTypes.func.isRequired,
-  onToggle: PropTypes.func.isRequired
+  onToggle: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 };
 
 export default TasksList;

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -258,6 +258,9 @@ export const canSave = (story) =>
 export const canDelete = (story) =>
   !isAccepted(story) && !isNew(story);
 
+export const canEdit = (story) => 
+  !isAccepted(story)
+
 export const withoutNewStory = (stories) =>
   stories.filter(story => !isNew(story));
 

--- a/spec/javascripts/components/story/expanded_story/attachment/attachment_list_spec.js
+++ b/spec/javascripts/components/story/expanded_story/attachment/attachment_list_spec.js
@@ -23,6 +23,7 @@ describe('<AttachmentList/>', () => {
       <AttachmentList
         files={attachments}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 
@@ -42,6 +43,7 @@ describe('<AttachmentList/>', () => {
       <AttachmentList
         files={attachments}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 

--- a/spec/javascripts/components/story/expanded_story/expanded_story_attachments_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_attachments_spec.js
@@ -67,9 +67,9 @@ describe('<ExpandedStoryAttachments />', () => {
     });
   });
 
-  describe('when disabled', () => {    
+  describe('when disabled', () => {
     it('does not render dropzone', () => {
-      const documents = [{id: 1}];
+      const documents = [{ id: 1 }];
       const story = { documents, _editing: { documents } };
 
       const wrapper = mount(

--- a/spec/javascripts/components/story/expanded_story/expanded_story_attachments_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_attachments_spec.js
@@ -19,6 +19,7 @@ describe('<ExpandedStoryAttachments />', () => {
         story={story}
         onAdd={onAdd}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 
@@ -40,11 +41,65 @@ describe('<ExpandedStoryAttachments />', () => {
         story={story}
         onAdd={onAdd}
         onDelete={onDelete}
+        disabled={false}
       />
     );
     const AttachmentsList = wrapper.find('AttachmentsList');
 
     expect(AttachmentsList).toExist();
     expect(AttachmentsList.prop('files')).toEqual(story._editing.documents)
+  });
+
+  describe('when enabled', () => {
+    it('renders dropzone', () => {
+      const story = { _editing: { documents: [] } };
+
+      const wrapper = mount(
+        <ExpandedStoryAttachments
+          story={story}
+          onAdd={onAdd}
+          onDelete={onDelete}
+          disabled={false}
+        />
+      );
+
+      expect(wrapper.exists('Dropzone')).toBe(true);
+    });
+  });
+
+  describe('when disabled', () => {    
+    it('does not render dropzone', () => {
+      const documents = [{id: 1}];
+      const story = { documents, _editing: { documents } };
+
+      const wrapper = mount(
+        <ExpandedStoryAttachments
+          story={story}
+          onAdd={onAdd}
+          onDelete={onDelete}
+          disabled={true}
+        />
+      );
+
+      expect(wrapper.exists('Dropzone')).toBe(false);
+    });
+
+    describe('when there are no attachments', () => {
+      it('renders nothing', () => {
+        const documents = [];
+        const story = { documents, _editing: { documents } };
+
+        const wrapper = mount(
+          <ExpandedStoryAttachments
+            story={story}
+            onAdd={onAdd}
+            onDelete={onDelete}
+            disabled={true}
+          />
+        );
+
+        expect(wrapper.html()).toBeNull();
+      });
+    });
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
@@ -22,7 +22,8 @@ describe('<ExpandedStoryDefault />', () => {
     addAttachment: sinon.spy(),
     removeAttachment: sinon.spy(),
     users: [],
-    project: { labels: [] }
+    project: { labels: [] },
+    enabled: true
   });
 
   it("renders all children components when isn't a new story", () => {

--- a/spec/javascripts/components/story/expanded_story/expanded_story_estimate_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_estimate_spec.js
@@ -6,7 +6,8 @@ describe('<ExpandedStoryEstimate />', () => {
   const defaultProps = () => ({
     story: {},
     project: {},
-    onEdit: sinon.spy()
+    onEdit: sinon.spy(),
+    disabled: false
   });
 
   it("renders component with 'Fibonacci' point scale in select", () => {
@@ -114,16 +115,36 @@ describe('<ExpandedStoryEstimate />', () => {
     });
 
     describe("to a feature", () => {
-      it("doesn't disable estimate select", () => {
-        const project = { pointValues: ['1', '2', '3', '4', '5'] };
-        const story = { _editing: { storyType: 'feature' } };
+      const project = { pointValues: ['1', '2', '3', '4', '5'] };
+      const story = { _editing: { storyType: 'feature' } };
 
+      it("doesn't disable estimate select when disabled prop is false", () => {
         const wrapper = shallow(
-          <ExpandedStoryEstimate {...defaultProps()} project={project} story={story} />
+          <ExpandedStoryEstimate 
+            {...defaultProps()}
+              project={project}
+              story={story}
+              disabled={false}
+          />
         );
         const select = wrapper.find('select');
 
         expect(select.prop('disabled')).not.toBe(true);
+      });
+
+      describe('when component is disabled', () => {
+        it("disables estimate select when disabled prop is true", () => {
+          const wrapper = shallow(
+            <ExpandedStoryEstimate
+              {...defaultProps()}
+              project={project}
+              story={story}
+              disabled={true}
+            />
+          );
+          const select = wrapper.find('select');
+          expect(select.prop('disabled')).toBe(true);
+        });
       });
     });
   });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_labels_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_labels_spec.js
@@ -3,39 +3,88 @@ import { shallow, mount } from 'enzyme';
 import ExpandedStoryLabels from 'components/story/ExpandedStory/ExpandedStoryLabels';
 
 describe('<ExpandedStoryLabels />', () => {
+  const defaultLabels = [
+    { id: 0, name: 'front' },
+    { id: 1, name: 'back' }
+  ];
+
   const defaultProps = () => ({
     onAddLabel: sinon.spy(),
     onRemoveLabel: sinon.spy(),
+    disabled: false,
     projectLabels: []
   });
+  
+  const setup = (propOverrides, labelOverrides) => {
+    const labels = labelOverrides || defaultLabels;
+    const story = { labels, _editing: { labels } };
+    const props = {
+      ...defaultProps(),
+      story,
+      ...propOverrides
+    };
+
+    const wrapper = shallow(<ExpandedStoryLabels {...props} />);
+    const reactTags = wrapper.find('ReactTags');
+    const { onRemoveLabel, onAddLabel } = props;
+
+    return { wrapper, reactTags, labels, onRemoveLabel, onAddLabel };
+  }
 
   it('renders component title', () => {
-    const labels = [
-      { id: 0, name: 'front' },
-      { id: 1, name: 'back' }
-    ];
-
-    const story = { _editing: { labels } }
+    const story = { _editing: { defaultLabels } }
     const wrapper = mount(
       <ExpandedStoryLabels {...defaultProps()} story={story} />
     );
-
+    
     expect(wrapper.text()).toContain(I18n.t('activerecord.attributes.story.labels'));
+  });
+
+  describe('when component is disabled', () => {
+    it('does not allow new labels', () => {
+      const { wrapper } = setup({ disabled: true });
+
+      expect(wrapper.find('ReactTags').prop('allowNew')).toBe(false);
+    });
+
+    it('does not allow deleting labels', () => {
+      const { wrapper, onRemoveLabel } = setup({ disabled: true });
+
+      wrapper.instance().handleDelete(0);
+
+      expect(onRemoveLabel).not.toHaveBeenCalled();
+    });
+
+    describe('when story has no labels', () => {
+      it('renders nothing', () => {
+        const { wrapper } = setup({ disabled: true }, []);
+
+        expect(wrapper.html()).toBeNull();
+      });
+    });
+  });
+
+  describe('when component is enabled', () => {
+    it('allows deleting labels', () => {
+      const { wrapper, onRemoveLabel } = setup();
+
+      wrapper.instance().handleDelete(0);
+
+      expect(onRemoveLabel).toHaveBeenCalled();
+    });
+
+    it('allows adding labels', () => {
+      const { wrapper, reactTags } = setup();
+
+      expect(reactTags.prop('allowNew')).toBe(true);
+    });
   });
 
   describe('<ReactTags />', () => {
     it('renders with the right tags prop', () => {
-      const labels = [
-        { id: 0, name: 'front' },
-        { id: 1, name: 'back' }
-      ];
+      const { wrapper, labels, reactTags } = setup();
 
-      const story = { _editing: { labels } }
-      const wrapper = shallow(
-        <ExpandedStoryLabels {...defaultProps()} story={story} />
-      );
-
-      expect(wrapper.find('ReactTags').prop('tags')).toEqual(labels);
+      expect(reactTags.prop('tags')).toEqual(labels);
     });
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
@@ -7,10 +7,10 @@ describe('<ExpandedStoryNotes />', () => {
   let onCreate;
   let onDelete;
 
-  const newStory = () => ({
-    ...storyFactory({ notes: [] }),
+  const newStory = notes => ({
+    ...storyFactory({ notes: notes || [] }),
     _editing: {
-      ...storyFactory({ notes: [] })
+      ...storyFactory({ notes: notes || [] })
     }
   })
 
@@ -27,6 +27,7 @@ describe('<ExpandedStoryNotes />', () => {
         story={story}
         onCreate={onCreate}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 
@@ -42,6 +43,7 @@ describe('<ExpandedStoryNotes />', () => {
         story={story}
         onCreate={onCreate}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 
@@ -51,47 +53,103 @@ describe('<ExpandedStoryNotes />', () => {
     expect(wrapper.find('NotesList')).toExist();
   });
 
-  it('disables the add note button if text area is empty', () => {
-    const story = newStory();
+  describe('when component is enabled', () => {
+    describe('when user create a new note', () => {
+      it('triggers the onCreate callback passing the note', () => {
+        const story = newStory();
+  
+        const change = 'newNote';
+  
+        const onCreateSpy = sinon.spy();
+  
+        const wrapper = shallow(
+          <ExpandedStoryNotes
+            story={story}
+            onCreate={onCreateSpy}
+            onDelete={onDelete}
+            disabled={false}
+          />
+        );
+  
+        const textArea = wrapper.find('.create-note-text');
+        const button = wrapper.find('.create-note-button input');
+  
+        textArea.simulate('change', { target: { value: change } });
+        button.simulate('click');
+  
+        expect(onCreateSpy).toHaveBeenCalledWith(change);
+      });
+    });
 
-    const wrapper = shallow(
-      <ExpandedStoryNotes
-        story={story}
-        onCreate={onCreate}
-        onDelete={onDelete}
-      />
-    );
-
-    const textArea = wrapper.find('.create-note-text');
-    const button = wrapper.find('.create-note-button input');
-
-    textArea.simulate('change', { target: { value: '' } });
-    expect(button.prop('disabled')).toBe(true);
-  });
-
-  describe('when user create a new note', () => {
-    it('triggers the onCreate callback passing the note', () => {
+    it('disables the add note button if text area is empty', () => {
       const story = newStory();
-
-      const change = 'newNote';
-
-      const onCreateSpy = sinon.spy();
-
+  
       const wrapper = shallow(
         <ExpandedStoryNotes
           story={story}
-          onCreate={onCreateSpy}
+          onCreate={onCreate}
           onDelete={onDelete}
+          disabled={false}
         />
       );
-
+  
       const textArea = wrapper.find('.create-note-text');
       const button = wrapper.find('.create-note-button input');
+  
+      textArea.simulate('change', { target: { value: '' } });
+      expect(button.prop('disabled')).toBe(true);
+    });
+  });
 
-      textArea.simulate('change', { target: { value: change } });
-      button.simulate('click');
+  describe('when component is disabled', () => {
+    it('does not render a create note button', () => {
+      const notes = [{id: 0, note: 'foo'}]
+      const story = newStory(notes);
+  
+      const wrapper = shallow(
+        <ExpandedStoryNotes
+          story={story}
+          onCreate={onCreate}
+          onDelete={onDelete}
+          disabled={true}
+        />
+      );
+      
+      expect(wrapper.exists('.create-note-button')).toBe(false);
+    });
 
-      expect(onCreateSpy).toHaveBeenCalledWith(change);
+    it('does not render a create note text area', () => {
+      const notes = [{id: 0, note: 'foo'}]
+      const story = newStory(notes);
+  
+      const wrapper = shallow(
+        <ExpandedStoryNotes
+          story={story}
+          onCreate={onCreate}
+          onDelete={onDelete}
+          disabled={true}
+        />
+      );
+      
+      expect(wrapper.exists('.create-note-text')).toBe(false);
+    });
+
+    describe('when there are no notes', () => {
+      it('renders nothing', () => {
+        const story = newStory();
+  
+        const wrapper = shallow(
+          <ExpandedStoryNotes
+            story={story}
+            onCreate={onCreate}
+            onDelete={onDelete}
+            disabled={true}
+          />
+        );
+
+        expect(wrapper.html()).toBeNull();
+      });
     });
   });
 });
+

--- a/spec/javascripts/components/story/expanded_story/expanded_story_owned_by_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_owned_by_spec.js
@@ -11,6 +11,7 @@ describe('<ExpandedStoryOwnedBy />', () => {
       ],
       story: { _editing: { ownedById: '' } },
       onEdit: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 

--- a/spec/javascripts/components/story/expanded_story/expanded_story_release/expanded_story_release_date_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_release/expanded_story_release_date_spec.js
@@ -9,6 +9,7 @@ describe('<ExpandedStoryReleaseDate />', () => {
       ...storyFactory(),
       _editing: storyFactory({ releaseDate: null })
     },
+    disabled: false,
     onEdit: sinon.spy()
   });
 

--- a/spec/javascripts/components/story/expanded_story/expanded_story_requested_by_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_requested_by_spec.js
@@ -11,11 +11,11 @@ describe('<ExpandedStoryRequestBy />', () => {
       ],
       story: { _editing: { requestedById: 1 } },
       onEdit: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 
     const wrapper = shallow(<ExpandedStoryRequestedBy {...defaultProps()} />);
-
     return { wrapper };
   };
 

--- a/spec/javascripts/components/story/expanded_story/expanded_story_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_spec.js
@@ -12,6 +12,7 @@ describe('<ExpandedStory />', () => {
     saveStory: sinon.spy(),
     deleteStory: sinon.spy(),
     project: { labels: [] },
+    disabled: false,
     onToggle: sinon.spy()
   });
 
@@ -59,6 +60,54 @@ describe('<ExpandedStory />', () => {
     });
   });
 
+  describe('when story is editable', () => {
+    const story = storyFactory({
+      _editing: {
+        ...storyFactory(),
+        storyType: 'feature',
+        state: 'unstarted'
+      }
+    });
+    
+    it('passes disabled prop as false', () => {
+      const wrapper = shallow(
+        <ExpandedStory
+          {...defaultProps()}
+          story={story}
+        />, 
+        { disableLifecycleMethods: true }
+      );
+      const expandedStoryDefault = wrapper.find(ExpandedStoryDefault);
+
+      expect(expandedStoryDefault.prop('disabled')).toBe(false);
+    });
+  });
+
+  describe('when story is not editable', () => {
+    const story = storyFactory({
+      _editing: {
+        ...storyFactory(),
+        storyType: 'feature',
+        state: 'accepted'
+      },
+      storyType: 'feature',
+      state: 'accepted'
+    });
+    
+    it('passes disabled prop as true', () => {
+      const wrapper = shallow(
+        <ExpandedStory
+          {...defaultProps()}
+          story={story}
+        />,
+        { disableLifecycleMethods: true }
+      );
+      const expandedStoryDefault = wrapper.find(ExpandedStoryDefault);
+
+      expect(expandedStoryDefault.prop('disabled')).toBe(true);
+    });
+  });
+
   it('adds enable-loading className when updating a story', () => {
     const story = storyFactory({
       _editing: {
@@ -76,5 +125,6 @@ describe('<ExpandedStory />', () => {
     );
 
     expect(wrapper.find('.Story__enable-loading')).toExist();
-  })
+  });
+
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_state_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_state_spec.js
@@ -9,7 +9,13 @@ describe('<ExpandedStoryState />', () => {
 
     const story = { state: 'started', _editing: { state: 'started' } };
 
-    const wrapper = mount(<ExpandedStoryState story={story} onEdit={onEditSpy} />);
+    const wrapper = mount(
+      <ExpandedStoryState 
+        story={story} 
+        onEdit={onEditSpy} 
+        disabled={false} 
+      />
+    );
 
     expect(wrapper.text()).toContain(I18n.t('activerecord.attributes.story.state'));
   });
@@ -23,7 +29,13 @@ describe('<ExpandedStoryState />', () => {
           _editing: { state: state }
         };
 
-        const wrapper = shallow(<ExpandedStoryState story={story} onEdit={onEditSpy} />);
+        const wrapper = shallow(
+          <ExpandedStoryState 
+            story={story} 
+            onEdit={onEditSpy}
+            disabled={false}
+          />
+        );
         const select = wrapper.find('select');
 
         expect(select.prop('value')).toBe(state);
@@ -42,7 +54,13 @@ describe('<ExpandedStoryState />', () => {
 
       const onEdit = sinon.spy();
 
-      const wrapper = shallow(<ExpandedStoryState story={story} onEdit={onEdit} />);
+      const wrapper = shallow(
+        <ExpandedStoryState 
+          story={story} 
+          onEdit={onEdit} 
+          disabled={false} 
+        />
+      );
       const select = wrapper.find('select');
 
       select.simulate('change', { target: { value: change } });
@@ -50,4 +68,37 @@ describe('<ExpandedStoryState />', () => {
       expect(onEdit).toHaveBeenCalledWith(change);
     });
   });
+
+  describe('when component is disabled', () => {
+    it('select field is editable', () => {
+      const onEditSpy = sinon.spy();
+      const story = { state: 'started', _editing: { state: 'started' } };
+      const wrapper = mount(
+        <ExpandedStoryState 
+          story={story} 
+          onEdit={onEditSpy}
+          disabled={true} 
+        />
+      );
+      const select = wrapper.find('select');
+      expect(select.prop('disabled')).toBe(true);
+    });
+  });
+
+  describe('when component is enabled', () => {
+    it('select field is enabled', () => {
+      const onEditSpy = sinon.spy();
+      const story = { state: 'started', _editing: { state: 'started' } };
+      const wrapper = mount(
+        <ExpandedStoryState 
+          story={story} 
+          onEdit={onEditSpy}
+          disabled={false} 
+        />
+      );
+      const select = wrapper.find('select');
+      expect(select.prop('disabled')).toBe(false);
+    });
+  });
+
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_task_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_task_spec.js
@@ -4,17 +4,18 @@ import ExpandedStoryTask from 'components/story/ExpandedStory/ExpandedStoryTask'
 import storyFactory from '../../../support/factories/storyFactory';
 
 describe('<ExpandedStoryTask />', () => {
-  const setup = propOverrides => {
+  const setup = (propOverrides, tasks) => {
     const defaultProps = () => ({
       story: {
         ...storyFactory({
-          tasks: [],
-          _editing: storyFactory({ tasks: [] })
+          tasks: tasks || [],
+          _editing: storyFactory({ tasks: tasks || [] })
         })
       },
       onDelete: sinon.spy(),
       onToggle: sinon.spy(),
       onSave: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 
@@ -32,32 +33,65 @@ describe('<ExpandedStoryTask />', () => {
     expect(wrapper.text()).toContain(I18n.t('story.tasks'));
   });
 
-  it('disables the add task button if text area is empty', () => {
-    const { input } = setup();
-    const { button } = setup();
+  describe('when component is enabled', () => {
+    it('displays a task form', () => {
+      const { wrapper } = setup();
 
-    input.simulate('change', { target: { value: '' } });
-    expect(button.prop('disabled')).toBe(true);
-  });
-
-  describe('onHandleSubmit', () => {
-    it('calls onSave with a task', () => {
-      const task = 'New Task';
-      const onSaveSpy = sinon.spy();
-      const { wrapperInstance } = setup({ onSave: onSaveSpy });
-      wrapperInstance.setState({ task })
-
-      wrapperInstance.onHandleSubmit();
-
-      expect(onSaveSpy).toHaveBeenCalledWith(task);
+      expect(wrapper.exists('.task-form')).toBe(true);
     });
 
-    it('calls setState with a empty task', () => {
-      const { wrapperInstance } = setup();
+    it('disables the add task button if text area is empty', () => {
+      const { input, button } = setup();
+  
+      input.simulate('change', { target: { value: '' } });
+      expect(button.prop('disabled')).toBe(true);
+    });
+  
+    describe('onHandleSubmit', () => {
+      it('calls onSave with a task', () => {
+        const task = 'New Task';
+        const onSaveSpy = sinon.spy();
+        const event = { target: { value: task } };
+        const { input, button } = setup({ onSave: onSaveSpy });
+        
+        input.simulate('change', event);
+        button.simulate('click');
+  
+        expect(onSaveSpy).toHaveBeenCalledWith(task);
+      });
+  
+      it('calls setState with a empty task', () => {
+        const { wrapperInstance } = setup();
+  
+        wrapperInstance.onHandleSubmit();
+  
+        expect(wrapperInstance.state.task).toEqual('');
+      });
+    });
+  });
 
-      wrapperInstance.onHandleSubmit();
+  describe('when component is disabled', () => {
+    const task = {
+      id: 0,
+      storyId: 0,
+      name: 'task',
+      done: false,
+      createdAt: "2019/04/01",
+      updatedAt: "2019/04/02"
+    };
 
-      expect(wrapperInstance.state.task).toEqual('');
+    it('does not display task form', () => {
+      const { wrapper } = setup({ disabled: true }, [task]);
+
+      expect(wrapper.exists('.task-form')).toBe(false);
+    });
+
+    describe('when there are no tasks', () => {
+      it('renders nothing', () => {
+        const { wrapper } = setup({ disabled: true });
+  
+        expect(wrapper.html()).toBeNull();
+      });
     });
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_title_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_title_spec.js
@@ -7,6 +7,7 @@ describe('<ExpandedStoryTitle />', () => {
     const defaultProps = () => ({
       story: { _editing: { title: 'foo' } },
       onEdit: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 
@@ -39,6 +40,22 @@ describe('<ExpandedStoryTitle />', () => {
       input.simulate('change', { target: { value: eventValue } })
 
       expect(mockOnEdit).toHaveBeenCalledWith(eventValue);
+    });
+
+    describe('when the component is enabled', () => {
+      it('should not be read-only', () => {
+        const { input } = setup({disabled: false});
+
+        expect(input.prop('readOnly')).toBe(false);
+      });
+    });
+
+    describe('when component is disabled', () => {
+      it('should be read-only', () => {
+        const { input } = setup({disabled: true});
+
+        expect(input.prop('readOnly')).toBe(true);
+      });
     });
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_type_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_type_spec.js
@@ -4,14 +4,41 @@ import ExpandedStoryType from 'components/story/ExpandedStory/ExpandedStoryType'
 import { types } from 'models/beta/story';
 
 describe('<ExpandedStoryType />', () => {
+  const setup = propOverrides => {
+    const defaultProps = {
+      onEdit: sinon.spy(),
+      story: { _editing: { storyType: 'feature' } },
+      disabled: false,
+      ...propOverrides
+    };
+    const wrapper = shallow(<ExpandedStoryType {...defaultProps} />);
+    const select = wrapper.find('select');
+
+    return { wrapper, select };
+  }
+
   types.forEach((type) => {
     it(`sets defaultValue as ${type} in select`, () => {
-      const onEdit = sinon.spy();
       const story = { _editing: { storyType: type } };
-      const wrapper = shallow(<ExpandedStoryType story={story} onEdit={onEdit} />);
-      const select = wrapper.find('select');
+      const { select } = setup({ story });
 
       expect(select.prop('value')).toBe(type);
+    });
+  });
+
+  describe('when component is not disabled', () => {
+    it('select field is editable', () => {
+      const { select } = setup();
+
+      expect(select.prop('disabled')).toBe(false);
+    });
+  });
+
+  describe('when component is disabled', () => {
+    it('select field is disabled', () => {
+      const { select } = setup({disabled: true});
+
+      expect(select.prop('disabled')).toBe(true);
     });
   });
 });

--- a/spec/javascripts/components/story/note/note_spec.js
+++ b/spec/javascripts/components/story/note/note_spec.js
@@ -12,7 +12,7 @@ describe('<Note/>', () => {
 
   const setup = propOverrides => {
     const onDeleteSpy = sinon.spy();
-  
+
     const wrapper = shallow(
       <Note
         note={note}
@@ -22,34 +22,34 @@ describe('<Note/>', () => {
       />
     );
 
-    const button = wrapper.find('.delete-note-button');
+    const deleteButton = wrapper.find('.delete-note-button');
 
-    return { wrapper, button, onDeleteSpy };
+    return { wrapper, deleteButton, onDeleteSpy };
   };
 
   describe('when component is enabled', () => {
     it('allows editing', () => {
-      const { button } = setup();
+      const { deleteButton } = setup();
 
-      expect(button.exists()).toBe(true);
+      expect(deleteButton.exists()).toBe(true);
     });
 
     describe('when user deletes a note', () => {
       it('triggers onDelete callback', () => {
-        const { button, onDeleteSpy } = setup();
-  
-        button.simulate('click');
-  
+        const { deleteButton, onDeleteSpy } = setup();
+
+        deleteButton.simulate('click');
+
         expect(onDeleteSpy).toHaveBeenCalled();
       });
     });
   });
-  
+
   describe('when component is disabled', () => {
     it('does not allow deleting', () => {
-      const { button } = setup({ disabled: true });
+      const { deleteButton } = setup({ disabled: true });
 
-      expect(button.exists()).toBe(false);
+      expect(deleteButton.exists()).toBe(false);
     });
   });
 });

--- a/spec/javascripts/components/story/note/note_spec.js
+++ b/spec/javascripts/components/story/note/note_spec.js
@@ -10,22 +10,46 @@ describe('<Note/>', () => {
     createdAt: '27/08/2018'
   };
 
-  describe('when user deletes a note', () => {
-    it('triggers onDelete callback', () => {
-      const onDeleteSpy = sinon.spy();
+  const setup = propOverrides => {
+    const onDeleteSpy = sinon.spy();
+  
+    const wrapper = shallow(
+      <Note
+        note={note}
+        onDelete={onDeleteSpy}
+        disabled={false}
+        {...propOverrides}
+      />
+    );
 
-      const wrapper = shallow(
-        <Note
-          note={note}
-          onDelete={onDeleteSpy}
-        />
-      );
+    const button = wrapper.find('.delete-note-button');
 
-      const button = wrapper.find('.delete-note-button');
+    return { wrapper, button, onDeleteSpy };
+  };
 
-      button.simulate('click');
+  describe('when component is enabled', () => {
+    it('allows editing', () => {
+      const { button } = setup();
 
-      expect(onDeleteSpy).toHaveBeenCalled();
+      expect(button.exists()).toBe(true);
+    });
+
+    describe('when user deletes a note', () => {
+      it('triggers onDelete callback', () => {
+        const { button, onDeleteSpy } = setup();
+  
+        button.simulate('click');
+  
+        expect(onDeleteSpy).toHaveBeenCalled();
+      });
+    });
+  });
+  
+  describe('when component is disabled', () => {
+    it('does not allow deleting', () => {
+      const { button } = setup({ disabled: true });
+
+      expect(button.exists()).toBe(false);
     });
   });
 });

--- a/spec/javascripts/components/story/note/notes_list_spec.js
+++ b/spec/javascripts/components/story/note/notes_list_spec.js
@@ -12,6 +12,7 @@ describe('<NotesList/>', () => {
       <NotesList
         notes={notesArray}
         onDelete={onDelete}
+        disabled={false}
       />
     );
 

--- a/spec/javascripts/components/story/select_user/select_user_spec.js
+++ b/spec/javascripts/components/story/select_user/select_user_spec.js
@@ -11,6 +11,7 @@ describe('<SelectUser />', () => {
       ],
       selectedUserId: 1,
       onEdit: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 
@@ -53,6 +54,22 @@ describe('<SelectUser />', () => {
       select.simulate('change', { target: { value: selectedUserId } });
 
       expect(select.props().value).toEqual('');
+    });
+  });
+
+  describe('when component is not disabled', () => {
+    it('select field is editable', () => {
+      const { select } = setup();
+
+      expect(select.prop('disabled')).toBe(false);
+    });
+  });
+
+  describe('when component is disabled', () => {
+    it('select field is disabled', () => {
+      const { select } = setup({disabled: true});
+
+      expect(select.prop('disabled')).toBe(true);
     });
   });
 });

--- a/spec/javascripts/components/story/task/task_list_spec.js
+++ b/spec/javascripts/components/story/task/task_list_spec.js
@@ -9,6 +9,7 @@ describe('<TasksList />', () => {
       tasks: tasksArray,
       onDelete: sinon.spy(),
       onToggle: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 

--- a/spec/javascripts/components/story/task/task_spec.js
+++ b/spec/javascripts/components/story/task/task_spec.js
@@ -13,6 +13,7 @@ describe('<Task />', () => {
       },
       onDelete: sinon.spy(),
       onToggle: sinon.spy(),
+      disabled: false,
       ...propOverrides
     });
 
@@ -45,4 +46,24 @@ describe('<Task />', () => {
       expect(onToggleCheckedBoxSpy).toHaveBeenCalled();
     });
   });
+
+  describe('when task is read-only', () => {
+    it('does not render a Delete span', () => {
+      const { span } = setup({ disabled: true });
+      
+      expect(span.exists()).toBe(false);
+    });
+
+    describe('when user tries to update the task clicking on checkbox', () => {
+      it('does not trigger onToggle callback', () => {
+        const onToggleCheckedBoxSpy = sinon.spy();
+        const { checkbox } = setup({ disabled: true });
+  
+        checkbox.simulate('click');
+  
+        expect(onToggleCheckedBoxSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
 });
+

--- a/spec/javascripts/components/story/task/task_spec.js
+++ b/spec/javascripts/components/story/task/task_spec.js
@@ -18,19 +18,19 @@ describe('<Task />', () => {
     });
 
     const wrapper = shallow(<Task {...defaultProps()} />);
-    const span = wrapper.find('.delete-btn');
+    const deleteLink = wrapper.find('.delete-btn');
     const label = wrapper.find('label');
     const checkbox = wrapper.find('input');
 
-    return { wrapper, span, label, checkbox };
+    return { wrapper, deleteLink, label, checkbox };
   };
 
   describe('when user deletes a task', () => {
     it('triggers onDelete callback', () => {
       const onDeleteSpy = sinon.spy();
-      const { span } = setup({ onDelete: onDeleteSpy })
+      const { deleteLink } = setup({ onDelete: onDeleteSpy })
 
-      span.simulate('click');
+      deleteLink.simulate('click');
 
       expect(onDeleteSpy).toHaveBeenCalled();
     });
@@ -48,19 +48,19 @@ describe('<Task />', () => {
   });
 
   describe('when task is read-only', () => {
-    it('does not render a Delete span', () => {
-      const { span } = setup({ disabled: true });
-      
-      expect(span.exists()).toBe(false);
+    it('does not render a link to delete task', () => {
+      const { deleteLink } = setup({ disabled: true });
+
+      expect(deleteLink.exists()).toBe(false);
     });
 
     describe('when user tries to update the task clicking on checkbox', () => {
       it('does not trigger onToggle callback', () => {
         const onToggleCheckedBoxSpy = sinon.spy();
         const { checkbox } = setup({ disabled: true });
-  
+
         checkbox.simulate('click');
-  
+
         expect(onToggleCheckedBoxSpy).not.toHaveBeenCalled();
       });
     });

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -438,6 +438,64 @@ describe('Story model', function () {
     });
   });
 
+  describe('canEdit', () => {
+    describe('when the story is accepted', () => {
+      it('returns false', () => {
+        const story = {state: 'accepted'};
+  
+        expect(Story.canEdit(story)).toBe(false);
+      });
+    });
+
+    describe(`when story is unscheduled`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'unscheduled'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+
+    describe(`when story is unstarted`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'unstarted'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+
+    describe(`when story is started`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'started'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+
+    describe(`when story is finished`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'finished'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+
+    describe(`when story is delivered`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'delivered'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+    
+    describe(`when story is rejected`, () => {
+      it(`returns true`, () => {
+        const story = {state: 'rejected'};
+  
+        expect(Story.canEdit(story)).toBe(true);
+      });
+    });
+  });
+
   describe('withoutNewStory', () => {
     it('remove a story with null id from a stories array', () => {
       const stories = [{ id: 1 }, { id: 2 }];


### PR DESCRIPTION
Disable input fields for read only stories [#23438](https://central.cm42.io/projects/central-board-v2#story-23438).

Before:
![before](https://user-images.githubusercontent.com/28638133/55183806-62a96880-516f-11e9-8b5e-eb6e3bd437e1.png)
After:
![after](https://user-images.githubusercontent.com/28638133/55183853-89679f00-516f-11e9-929c-63b6e6782d45.png)

Note that if a component has no content and the story is read-only the render method will return `null` (i.e. "Attachments" on the example above) 