### PR TITLE
Add a PopOver component

### DIFF
--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryControls.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryControls.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ExpandedStoryToolTip from './ExpandedStoryToolTip'
 
 class ExpandedStoryControls extends Component {
   constructor(props) {
@@ -31,7 +32,7 @@ class ExpandedStoryControls extends Component {
   }
 
   render() {
-    const { onSave, canSave, canDelete } = this.props;
+    const { onSave, canSave, canDelete, disabled } = this.props;
 
     return (
       <div className="form-group Story__controls">
@@ -54,6 +55,17 @@ class ExpandedStoryControls extends Component {
           type="button"
           value={I18n.t('cancel')}
         />
+
+        {
+          disabled && (
+            <button className="btnToolTip">
+              <ExpandedStoryToolTip text={I18n.t('accepted_tooltip')}>
+              ?
+              </ExpandedStoryToolTip> 
+            </button>
+          )
+        }
+
       </div>
     );
   }
@@ -64,7 +76,8 @@ ExpandedStoryControls.propTypes = {
   onCancel: PropTypes.func.isRequired,
   canSave: PropTypes.bool.isRequired,
   canDelete: PropTypes.bool.isRequired,
-  isDirty: PropTypes.bool.isRequired
+  isDirty: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default ExpandedStoryControls;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryToolTip.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryToolTip.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Popover from 'components/jquery_wrappers/Popover.js';
+
+const ExpandedStoryToolTip = ({ text, children }) => (
+
+  <Popover
+    delay={100}
+    trigger="hover"
+    title=""
+    renderContent={({ ref }) => (
+      <div ref={ref}>
+       {text}
+      </div>
+    )}
+  >
+    {
+      ({ ref }) => (
+        <div ref={ref}>
+          { children }
+        </div>
+      )
+    }
+  </Popover>
+);
+
+export default ExpandedStoryToolTip;

--- a/app/assets/javascripts/components/story/ExpandedStory/index.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/index.js
@@ -49,6 +49,7 @@ export class ExpandedStory extends React.Component {
           onDelete={() => deleteStory(story.id, project.id)}
           canSave={Story.canSave(story)}
           canDelete={Story.canDelete(story)}
+          disabled={disabled}
         />
 
         {

--- a/app/assets/stylesheets/new_board/_story.scss
+++ b/app/assets/stylesheets/new_board/_story.scss
@@ -346,6 +346,17 @@
             @extend .btn-default;
             @extend .btn-xs;
           }
+          
+          .btnToolTip {
+            background-color: #fff;
+            border: 1px solid transparent;
+            border-color: #ccc;
+            border-radius: 3px;
+            color: red;
+            font-size: 12px;
+            height: 22px;
+            width: 30px;
+          }
         }
 
         &__loading {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
   stories_not_found: "Stories not found"
   upload_new_file: "Drop files here, or click to upload."
   reject_new_file: "Unsupported file type."
+  accepted_tooltip: "The task has already been accepted. It can't be modified."
 
   story:
     state:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -75,6 +75,7 @@ es:
   stories_not_found: "Historias no encontradas"
   upload_new_file: "Arrastre el archivo aquí, o haga clic para agregar."
   reject_new_file: "Tipo de archivo no soportado."
+  accepted_tooltip: "La tarea ya ha sido aceptada. No se puede modificar."
 
   story:
     state:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -76,6 +76,8 @@ pt-BR:
   stories_not_found: "Histórias não encontradas"
   upload_new_file: "Arraste o arquivo aqui, ou clique para adicionar."
   reject_new_file: "Formato não suportado."
+  accepted_tooltip: "A Tarefa já foi entregue, não pode ser modificada."
+
 
   story:
     state:


### PR DESCRIPTION
This PR is to add a popover component in which tells the user that when a task is accepted it can no longer be modified. 
This functionality is for beta version.

![popOverToolTip](https://user-images.githubusercontent.com/10763483/56898670-fec4d900-6a67-11e9-98eb-8622db58cb7a.png)
