### PR TITLE
Feature/done column icons

### DIFF
--- a/app/assets/javascripts/components/stories/SprintHeader.js
+++ b/app/assets/javascripts/components/stories/SprintHeader.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DefaultPoints = ({ points, completedPoints }) => (
+  <div className="default-points">
+    {completedPoints > 0 && `${completedPoints} / `}
+    {points}
+  </div>
+);
+
+const expandedStyle = (hasStories, isClosed) =>
+  hasStories && !isClosed ? 'Sprint__icon--expanded' : ''
+
+const DonePoints = ({ points, hasStories, isClosed }) => (
+  <div>
+    <span className="done-points">{points > 0 && points}</span>
+    <i
+      className={`Sprint__icon ${expandedStyle(hasStories, isClosed)} mi md-16`}
+    >
+      {hasStories ? 'chevron_right' : 'remove'}
+    </i>
+  </div>
+);
+
+const SprintHeader = props => (
+  <div className="Sprint__header" onClick={props.onClick}>
+    {props.number} - {I18n.l("date.formats.long", props.startDate)}
+    {
+      props.isDone
+        ? <DonePoints
+          hasStories={props.hasStories}
+          points={props.points}
+          isClosed={props.isClosed}
+        />
+        : <DefaultPoints
+          points={props.points}
+          completedPoints={props.completedPoints}
+        />
+    }
+  </div>
+);
+
+
+SprintHeader.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  number: PropTypes.number.isRequired,
+  startDate: PropTypes.string.isRequired,
+  isDone: PropTypes.bool.isRequired,
+  hasStories: PropTypes.bool,
+  points: PropTypes.number.isRequired,
+  isClosed: PropTypes.bool.isRequired,
+  completedPoints: PropTypes.number
+}
+
+export default SprintHeader

--- a/app/assets/stylesheets/new_board/_sprint.scss
+++ b/app/assets/stylesheets/new_board/_sprint.scss
@@ -3,13 +3,22 @@
     padding: 5px 10px;
     font-size: 11px;
     color: $lightgrey-12;
+    display: flex;
+    justify-content: space-between;
     background-color: $darkgrey-7;
     border-top: 1px solid $darkgrey-8;
     border-bottom: 1px solid $darkgrey-9;
   }
 
-  &__points {
-    float: right;
+  &__icon {
+    margin-left: 8px;
+    transition: transform .4s cubic-bezier(0.075, 0.82, 0.165, 1);
+    -webkit-transition: -webkit-transform .4s cubic-bezier(0.075, 0.82, 0.165, 1);
+
+    &--expanded {
+      transform:rotate(90deg);
+      -webkit-transform:rotate(90deg);
+    }
   }
 
   &__body {

--- a/app/models/iterations/past_iteration.rb
+++ b/app/models/iterations/past_iteration.rb
@@ -7,6 +7,7 @@ module Iterations
     attribute :iteration_number, Integer
     attribute :stories, Array[Story]
     attribute :points, Integer
+    attribute :has_stories, Boolean
 
     def points
       @points ||= stories.to_a.map(&:estimate).compact.sum

--- a/app/models/iterations/project_iterations.rb
+++ b/app/models/iterations/project_iterations.rb
@@ -21,11 +21,14 @@ module Iterations
           end_at = iteration_end_date(start_at)
         end
 
+        iteration_stories = stories_between(start_at, end_at)
+
         PastIteration.new(
           start_date: start_at,
           end_date: end_at,
           iteration_number: iteration_number + 1,
-          points: points_of_stories_between(start_at, end_at)
+          points: points_of_stories(iteration_stories),
+          has_stories: iteration_stories.any?
         )
       end
     end
@@ -34,8 +37,8 @@ module Iterations
 
     attr_reader :project, :stories
 
-    def points_of_stories_between(start_at, end_at)
-      stories_between(start_at, end_at).to_a.map(&:estimate).compact.sum
+    def points_of_stories(stories)
+      stories.to_a.map(&:estimate).compact.sum
     end
 
     def stories_between(start_at, end_at)

--- a/spec/javascripts/components/stories/sprint_header_spec.js
+++ b/spec/javascripts/components/stories/sprint_header_spec.js
@@ -1,0 +1,176 @@
+import React from "react";
+import { mount } from "enzyme";
+import SprintHeader from "components/stories/SprintHeader";
+
+const defaultProps = {
+  number: 42,
+  onClick: sinon.stub(),
+  startDate: '1420/01/01',
+  isDone: false,
+  points: 420,
+  isClosed: false,
+  completedPoints: 111
+};
+
+const mergeProps = overrides => ({ ...defaultProps, ...overrides });
+
+const renderWrapper = overrides => mount(
+  <SprintHeader {...mergeProps(overrides)} />
+);
+
+describe('<SprintHeader />', () => {
+  let wrapper, onClick
+
+  beforeEach(() => {
+    onClick = sinon.stub();
+    wrapper = renderWrapper({ onClick });
+  });
+
+  it('Renders a div with class of "Sprint__header"', () => {
+    const header = wrapper.find('div.Sprint__header');
+
+    expect(header.exists()).toBe(true);
+  });
+
+  it('Calls onClick prop when div is clicked', () => {
+    const header = wrapper.find('div.Sprint__header');
+
+    header.simulate('click');
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('displays iteration number', () => {
+    expect(wrapper.html()).toContain('42');
+  });
+
+  it('displays iteration start date', () => {
+    const expected = I18n.l("date.formats.long", defaultProps.startDate);
+
+    expect(wrapper.html()).toContain(expected);
+  })
+
+  describe('default sprints', () => {
+    it('shows sprint points', () => {
+      expect(wrapper.find('div.default-points').html()).toContain('420');
+    });
+
+    describe('when there are completed points', () => {
+      it('shows completed points', () => {
+        expect(wrapper.find('div.default-points').html()).toContain('111');
+      })
+    });
+  });
+
+  describe('done sprints', () => {
+    describe('when sprint has points', () => {
+      beforeEach(() => {
+        wrapper = renderWrapper({
+          hasStories: true,
+          isDone: true
+        });
+      });
+
+      it('shows sprint points', () => {
+        const donePoints = wrapper.find('span.done-points');
+
+        expect(donePoints.html()).toContain('420');
+      });
+    });
+
+    describe('when sprint has no points', () => {
+      beforeEach(() => {
+        wrapper = renderWrapper({
+          isClosed: true,
+          hasStories: true,
+          isDone: true,
+          points: 0
+        });
+      });
+
+      it('does not show sprint points', () => {
+        const donePoints = wrapper.find('span.done-points');
+
+        expect(donePoints.children().length).toBe(0);
+      });
+    });
+
+    describe('when sprint has stories', () => {
+      beforeEach(() => {
+        wrapper = renderWrapper({
+          isDone: true,
+          hasStories: true,
+          isClosed: true
+        });
+      });
+
+      it('shows expand icon', () => {
+        const icon = wrapper.find('i.Sprint__icon');
+
+        expect(icon.html()).toContain('chevron_right');
+      });
+
+      describe('when sprint is closed', () => {
+        it('does not have expanded modifier class', () => {
+          const icon = wrapper.find('i.Sprint__icon');
+
+          expect(icon).not.toHaveClassName('Sprint__icon--expanded');
+        });
+      });
+
+      describe('when sprint is expanded', () => {
+        beforeEach(() => {
+          wrapper = renderWrapper({
+            isDone: true,
+            hasStories: true,
+          });
+        });
+
+        it('has expanded modifier class', () => {
+          const icon = wrapper.find('i.Sprint__icon');
+
+          expect(icon).toHaveClassName('Sprint__icon--expanded');
+        });
+      });
+    });
+
+    describe('when sprint has no stories', () => {
+      beforeEach(() => {
+        wrapper = renderWrapper({
+          isDone: true,
+          hasStories: false,
+          isClosed: true
+        });
+      });
+
+      it('shows "-" icon', () => {
+        const icon = wrapper.find('i.Sprint__icon');
+
+        expect(icon.html()).toContain('remove');
+      });
+
+      describe('when isClosed prop is true', () => {
+        it('does not have expanded modifier class', () => {
+          const icon = wrapper.find('i.Sprint__icon');
+
+          expect(icon).not.toHaveClassName('Sprint__icon--expanded');
+        });
+      });
+
+      describe('when isClosed prop is false', () => {
+        beforeEach(() => {
+          wrapper = renderWrapper({
+            isDone: true,
+            hasStories: false,
+          });
+        });
+
+        it('does not have expanded modifier class', () => {
+          const icon = wrapper.find('i.Sprint__icon');
+
+          expect(icon).not.toHaveClassName('Sprint__icon--expanded');
+        });
+      });
+    });
+  });
+});

--- a/spec/javascripts/components/stories/sprint_spec.js
+++ b/spec/javascripts/components/stories/sprint_spec.js
@@ -33,15 +33,15 @@ const createSprint = propOverrides => ({
 describe("<Sprint />", () => {
   beforeEach(() => {
     sprint = createSprint();
-    wrapper = shallow(<Sprint sprint={ sprint } />);
+    wrapper = shallow(<Sprint sprint={sprint} />);
   });
 
   it('renders a <div> with class ".Sprint"', () => {
     expect(wrapper.find("div.Sprint").exists()).toBe(true);
   });
 
-  it('renders a div with class ".Sprint__header"', () => {
-    expect(wrapper.find("div.Sprint__header").exists()).toBe(true);
+  it('renders a SprintHeader component"', () => {
+    expect(wrapper.find('SprintHeader').exists()).toBe(true);
   });
 
   it('renders a div with class ".Sprint__body"', () => {
@@ -56,7 +56,7 @@ describe("<Sprint />", () => {
     beforeEach(() => {
       sprint = createSprint();
       sprint.stories = null;
-      wrapper = shallow(<Sprint sprint={ sprint } />);
+      wrapper = shallow(<Sprint sprint={sprint} />);
     });
 
     it("does not render any <Stories> component", () => {
@@ -66,18 +66,18 @@ describe("<Sprint />", () => {
 
   describe('when story needs to fetch', () => {
     let fetchStories;
-    
+
     beforeEach(() => {
-      sprint = createSprint({ fetching: false, isFetched: false });
+      sprint = createSprint({ fetching: false, isFetched: false, hasStories: true });
       sprint.stories = null;
       fetchStories = sinon.stub();
-      wrapper = shallow(<Sprint sprint={ sprint } fetchStories={fetchStories} />);
+      wrapper = shallow(<Sprint sprint={sprint} fetchStories={fetchStories} />);
     });
 
     it('calls fetchStories with iteration number, start and end date on user click', () => {
       const { number, startDate, endDate } = sprint;
-      const header = wrapper.find('.Sprint__header');
-      
+      const header = wrapper.find('SprintHeader');
+
       header.simulate('click');
 
       expect(fetchStories).toHaveBeenCalledWith(number, startDate, endDate);

--- a/spec/models/iterations/project_iterations_spec.rb
+++ b/spec/models/iterations/project_iterations_spec.rb
@@ -30,6 +30,24 @@ module Iterations
         expect(subject.past_iterations).to all(be_a(PastIteration))
       end
 
+      context 'when iteration has no stories' do
+        it 'has_stories flag is false' do
+
+          flags = subject.past_iterations.map{ |iteration| iteration.has_stories }
+          expect(flags).to all(eq(false))
+        end
+      end
+
+      context 'when iteration has stories' do
+        let(:story) { create(:story, :done, :with_project) }
+        let(:project) { story.project }
+
+        it 'has_stories flag is true' do
+          flags = subject.past_iterations.map{ |iteration| iteration.has_stories }
+          expect(flags).to all(eq(true))
+        end
+      end
+
       context 'when project start in the same week day as the iterations' do
         let(:story) { create(:story, :done, :with_project) }
         let(:project) { story.project }


### PR DESCRIPTION
## Add icons to done column sprints 

### What [#23883](https://central.cm42.io/projects/central-board-v2#story-23883)
* Expand icon when sprint can be expanded
* "-" when sprint cannot expand
* Do not display points when it amounts to zero

### How

* Send has_stories flag from backend
* Add a SprintHeader component
* Refactor Sprint component
* Add tests

### Before

![central-icon-b4](https://user-images.githubusercontent.com/28638133/58987426-d7270600-87b5-11e9-9ca0-137c7dde9aae.png)

### After

![central-icons-after](https://user-images.githubusercontent.com/28638133/58987427-d7270600-87b5-11e9-94a7-b0e468d6ba57.png)
