### PR TITLE
Freeze wrong time

### DIFF
--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -100,7 +100,7 @@ describe StoriesController do
         before do
           create(:note, story: active_story)
 
-          Timecop.freeze Time.utc(2019, 1, 1, 12, 0, 0, 0).in_time_zone do
+          Timecop.freeze(2019, 1, 1, 12, 0, 0, 0) do
             get :index, format: :csv, params: { project_id: project.id }
           end
         end


### PR DESCRIPTION
# Freezing time with wrong time zone

### Bug
The time is freezing with the wrong time zone which causes the test to go red in some machines.

### Solution
Pass the parameters directly to the `freeze` method which already normalize the time zone when freezing the time.