### PR TITLE
Project navbar links v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - [ V2 ] Fix number, date and points of sprints.
 
 ### Added
+- [ V2 ] Add project navigation bar
 - [ V2 ] Fetch and show stories on the done column
 - [ V2 ] Story:
   - Stories of release type

--- a/app/controllers/beta/projects_controller.rb
+++ b/app/controllers/beta/projects_controller.rb
@@ -4,6 +4,7 @@ class Beta::ProjectsController < ApplicationController
   def show
     authorize current_user
     @project_id = params[:id]
+    @project = current_user.projects.friendly.find @project_id
   end
 
   private

--- a/app/views/beta/projects/show.html.erb
+++ b/app/views/beta/projects/show.html.erb
@@ -1,1 +1,5 @@
+<% content_for :navbar do %>
+  <%= render 'projects/navbar', project: @project %>
+<% end %>
+
 <div data-app data-project-id="<%= @project_id %>" class="full-heigth"></div>


### PR DESCRIPTION
# Add project navbar links

### Feature
Add the project navigation bar links in the v2 board.

Obs: currently the links will redirect to the v1 but in the future when the v2 get done the links will work as they should.

### View
#### Before
![image](https://user-images.githubusercontent.com/24780712/66070590-f6e1f700-e527-11e9-9bf0-ca830fd52829.png)

#### After
![image](https://user-images.githubusercontent.com/24780712/66070546-e467bd80-e527-11e9-9244-6ae701dcd86d.png)
