### PR TITLE
Change chilly bin rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,10 @@ and CVE-2018-14567)
 ### Changed
 - Reversed the order of done column sprints
 
+### Changed
+- Unscheduled stories may or not may have a estimate.
+- Chilly Bin column have stories with or no estimate.
+
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 

--- a/app/assets/javascripts/models/beta/column.js
+++ b/app/assets/javascripts/models/beta/column.js
@@ -1,9 +1,7 @@
 import * as iteration from "./iteration";
 import * as Story from "./story";
 
-export const isChillyBin = (story) => {
-  return Story.isUnscheduled(story);
-};
+export const isChillyBin = (story) => Story.isUnscheduled(story);
 
 export const isBacklog = (story, project) => {
   const currentIteration = iteration.getCurrentIteration(project);

--- a/app/assets/javascripts/models/beta/column.js
+++ b/app/assets/javascripts/models/beta/column.js
@@ -1,7 +1,7 @@
 import * as iteration from "./iteration";
 import * as Story from "./story";
 
-export const isChillyBin = (story) => Story.isUnscheduled(story);
+export const isChillyBin = story => Story.isUnscheduled(story);
 
 export const isBacklog = (story, project) => {
   const currentIteration = iteration.getCurrentIteration(project);

--- a/app/assets/javascripts/models/beta/column.js
+++ b/app/assets/javascripts/models/beta/column.js
@@ -1,7 +1,7 @@
 import * as iteration from "./iteration";
 import * as Story from "./story";
 
-export const isChillyBin = story => Story.isUnscheduled(story);
+export const isChillyBin = Story.isUnscheduled;
 
 export const isBacklog = (story, project) => {
   const currentIteration = iteration.getCurrentIteration(project);

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -156,9 +156,6 @@ export const toggleStory = (story) => {
   };
 };
 
-const isUnstartedState = (story, newAttributes) => 
-  !hasEstimate(story) && hasEstimate(newAttributes)
-
 const isUnscheduledState = (story, newAttributes) => 
   (
     isFeature(story._editing) && (
@@ -175,17 +172,11 @@ const isChangingToUnscheduled = (story, newAttributes) => isUnscheduled(story._e
 
 const isChangingWithoutEstimate = (story, newAttributes) => !hasEstimate(story._editing) && !hasEstimate(newAttributes)
 
-const stateFor = (story, newAttributes, newStory) => {
-  const { UNSTARTED, UNSCHEDULED } = status;
-
-  if (isUnstartedState(story._editing, newAttributes)) return UNSTARTED;
-  if (isUnscheduledState(story, newAttributes)) return UNSCHEDULED;
-  
-  return newStory.state;
-}
+const stateFor = (story, newAttributes, newStory) =>
+  isUnscheduledState(story, newAttributes) ? status.UNSCHEDULED : newStory.state;
 
 const estimateFor = (story, newAttributes, newStory) => {
-  if (isNoEstimated(story, newAttributes) || isUnscheduledState(story, newAttributes)) return '';
+  if (isNoEstimated(story, newAttributes)) return '';
   if (isFeature(newAttributes) && !isUnscheduled(story._editing)) return 1;
   
   return newStory.estimate;

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -172,10 +172,10 @@ const isChangingToUnscheduled = (story, newAttributes) => isUnscheduled(story._e
 
 const isChangingWithoutEstimate = (story, newAttributes) => !hasEstimate(story._editing) && !hasEstimate(newAttributes)
 
-const stateFor = (story, newAttributes, newStory) =>
+export const stateFor = (story, newAttributes, newStory) =>
   isUnscheduledState(story, newAttributes) ? status.UNSCHEDULED : newStory.state;
 
-const estimateFor = (story, newAttributes, newStory) => {
+export const estimateFor = (story, newAttributes, newStory) => {
   if (isNoEstimated(story, newAttributes)) return '';
   if (isFeature(newAttributes) && !isUnscheduled(story._editing)) return 1;
   

--- a/app/assets/javascripts/selectors/done.js
+++ b/app/assets/javascripts/selectors/done.js
@@ -1,5 +1,3 @@
-import moment from "moment";
-
 export const mountPastIterations = (pastIterations, stories) =>
   pastIterations.map(sprint => ({
     ...sprint,

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -10,21 +10,11 @@ module StoryOperations
     include PusherNotification
     include StateEnsurement
 
-    def before_save
-      ensure_valid_state
-    end
-
     def after_save
       model.changesets.create!
 
       notify_users
       notify_changes
-    end
-
-    private
-
-    def ensure_valid_state
-      model.state = 'unstarted' if should_be_unstarted? estimate: model.estimate, state: model.state
     end
   end
 
@@ -52,11 +42,8 @@ module StoryOperations
     private
 
     def ensure_valid_state
-      if should_be_unstarted? estimate: params['estimate'], state: params['state']
-        params['state'] = 'unstarted'
-      elsif should_be_unscheduled? estimate: params['estimate'], type: params['story_type']
-        params['state'] = 'unscheduled'
-      end
+      params['state'] = 'unscheduled' if
+      should_be_unscheduled? estimate: params['estimate'], type: params['story_type']
     end
 
     def documents_changed?

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -42,8 +42,9 @@ module StoryOperations
     private
 
     def ensure_valid_state
-      params['state'] = 'unscheduled' if
-      should_be_unscheduled? estimate: params['estimate'], type: params['story_type']
+      return unless should_be_unscheduled? estimate: params['estimate'], type: params['story_type']
+
+      params['state'] = 'unscheduled'
     end
 
     def documents_changed?

--- a/app/operations/story_operations/state_ensurement.rb
+++ b/app/operations/story_operations/state_ensurement.rb
@@ -1,9 +1,5 @@
 module StoryOperations
   module StateEnsurement
-    def should_be_unstarted?(estimate:, state:)
-      estimate.present? && state == 'unscheduled'
-    end
-
     def should_be_unscheduled?(estimate:, type:)
       Story.can_be_estimated?(type) && estimate.blank?
     end

--- a/spec/features/stories_spec.rb
+++ b/spec/features/stories_spec.rb
@@ -119,7 +119,7 @@ describe 'Stories' do
         find('#estimate-1').click
       end
 
-      within(in_progress_column.find('.story')) do
+      within(chilly_bin_column.find('.story')) do
         click_on 'start'
       end
 

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -4,7 +4,6 @@ import { status, storyTypes, storyScopes } from 'libs/beta/constants';
 
 describe('Story model', function () {
   describe('comparePosition', () => {
-
     describe('when position A is bigger then B', () => {
       it("return 1", () => {
         const storyA = {
@@ -1273,6 +1272,90 @@ describe('Story model', function () {
         const story = { id: 100 };
 
         expect(Story.haveStory(story, stories)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('stateFor', () => {
+    const { BUG, CHORE, RELEASE } = storyTypes;
+    const { UNSTARTED, UNSCHEDULED } = status;
+
+    describe('when is feature', () => {
+      describe('and have not estimate', () => {
+        const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: '' } };
+        const newAttributes = { state: UNSTARTED }
+        const newStory = { ...story, ...newAttributes };
+
+        it(`return ${UNSCHEDULED}`, () => {
+          expect(Story.stateFor(story, newAttributes, newStory)).toEqual(UNSCHEDULED);
+        });
+      });
+
+      describe('and new attributes have not estimate', () => {
+        const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: 2 } };
+        const newAttributes = { estimate: '' };
+        const newStory = { ...story, ...newAttributes };
+
+        it(`return ${UNSCHEDULED}`, () => {
+          expect(Story.stateFor(story, newAttributes, newStory)).toEqual(UNSCHEDULED);
+        });
+      });
+
+      describe(`and new attributes have state ${UNSCHEDULED}`, () => {
+        const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: 2 } };
+        const newAttributes = { state: UNSCHEDULED };
+        const newStory = { ...story, ...newAttributes };
+
+        it(`return ${UNSCHEDULED}`, () => {
+          expect(Story.stateFor(story, newAttributes, newStory)).toEqual(UNSCHEDULED);
+        });
+      });
+    });
+
+    const noFeatureTypes = [BUG, CHORE, RELEASE];
+
+    noFeatureTypes.forEach(noFeatureType => {
+      describe(`when is ${noFeatureType}`, () => {
+        Story.states.forEach(state => {
+          describe(`and new attributes is state ${state}`, () => {
+            const story = { _editing: { id: 1, storyType: noFeatureType, estimate: 2 } };
+            const newAttributes = { state };
+            const newStory = { ...story, ...newAttributes };
+
+            it(`return ${state}`, () => {
+              expect(Story.stateFor(story, newAttributes, newStory)).toEqual(state);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('estimateFor', () => {
+    const { BUG, CHORE, RELEASE } = storyTypes;
+    const noFeatureTypes = [BUG, CHORE, RELEASE];
+
+    noFeatureTypes.forEach(noFeatureType => {
+      describe(`when story type is ${noFeatureType}`, () => {
+        describe('and new attributes have estimate 2', () => {
+          const story = { _editing: { id: 1, storyType: noFeatureType, estimate: '' } };
+          const newAttributes = { estimate: 2 };
+          const newStory = { ...story, ...newAttributes };
+  
+          it(`return ''`, () => {
+            expect(Story.estimateFor(story, newAttributes, newStory)).toEqual('');
+          });
+        });
+
+        describe('and new attributes have story type feature', () => {
+          const story = { _editing: { id: 1, storyType: noFeatureType, estimate: '' } };
+          const newAttributes = { storyType: 'feature' };
+          const newStory = { ...story, ...newAttributes };
+
+          it(`return 1`, () => {
+            expect(Story.estimateFor(story, newAttributes, newStory)).toEqual(1);
+          });
+        });
       });
     });
   });

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -283,8 +283,8 @@ describe('Story model', function () {
             changedStory = Story.editStory(story, newAttributes);
           });
           
-          it("change estimate to ''", () => {    
-            expect(changedStory._editing.estimate).toEqual('');
+          it("keep estimate 1", () => {    
+            expect(changedStory._editing.estimate).toEqual(1);
           });
 
           it(`change state to ${UNSCHEDULED}`, () => {
@@ -326,8 +326,8 @@ describe('Story model', function () {
               changedStory = Story.editStory(story, newAttributes);
             });
 
-            it(`change story state to ${UNSTARTED}`, () => {
-              expect(changedStory._editing.state).toEqual(UNSTARTED);
+            it(`keept change story state to ${UNSCHEDULED}`, () => {
+              expect(changedStory._editing.state).toEqual(UNSCHEDULED);
             });
 
             it(`change estimate to ${estimatedValue}`, () => {

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -1281,7 +1281,7 @@ describe('Story model', function () {
     const { UNSTARTED, UNSCHEDULED } = status;
 
     describe('when is feature', () => {
-      describe('and have not estimate', () => {
+      describe('and have no estimate', () => {
         const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: '' } };
         const newAttributes = { state: UNSTARTED }
         const newStory = { ...story, ...newAttributes };
@@ -1291,7 +1291,7 @@ describe('Story model', function () {
         });
       });
 
-      describe('and new attributes have not estimate', () => {
+      describe('and new attributes have no estimate', () => {
         const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: 2 } };
         const newAttributes = { estimate: '' };
         const newStory = { ...story, ...newAttributes };

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -1280,7 +1280,7 @@ describe('Story model', function () {
     const { BUG, CHORE, RELEASE } = storyTypes;
     const { UNSTARTED, UNSCHEDULED } = status;
 
-    describe('when is feature', () => {
+    describe('when is a feature', () => {
       describe('and have no estimate', () => {
         const story = { _editing: { id: 1, storyType: storyTypes.FEATURE, estimate: '' } };
         const newAttributes = { state: UNSTARTED }

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -326,7 +326,7 @@ describe('Story model', function () {
               changedStory = Story.editStory(story, newAttributes);
             });
 
-            it(`keept change story state to ${UNSCHEDULED}`, () => {
+            it(`keep story state ${UNSCHEDULED}`, () => {
               expect(changedStory._editing.state).toEqual(UNSCHEDULED);
             });
 

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -1342,7 +1342,7 @@ describe('Story model', function () {
           const newAttributes = { estimate: 2 };
           const newStory = { ...story, ...newAttributes };
   
-          it(`return ''`, () => {
+          it('return an empty string', () => {
             expect(Story.estimateFor(story, newAttributes, newStory)).toEqual('');
           });
         });
@@ -1352,7 +1352,7 @@ describe('Story model', function () {
           const newAttributes = { storyType: 'feature' };
           const newStory = { ...story, ...newAttributes };
 
-          it(`return 1`, () => {
+          it('return 1', () => {
             expect(Story.estimateFor(story, newAttributes, newStory)).toEqual(1);
           });
         });

--- a/spec/operations/story_operations/state_ensurement_spec.rb
+++ b/spec/operations/story_operations/state_ensurement_spec.rb
@@ -3,28 +3,6 @@ require 'rails_helper'
 describe StoryOperations::StateEnsurement do
   let(:state_ensurement) { Class.new { extend StoryOperations::StateEnsurement } }
 
-  describe '#should_be_unstarted?' do
-    subject { state_ensurement.should_be_unstarted?(params) }
-
-    context 'when is estimated and unscheduled' do
-      let(:params) { { estimate: 1, state: 'unscheduled' } }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context 'when is estimated and not unscheduled' do
-      let(:params) { { estimate: 1, state: 'started' } }
-
-      it { is_expected.to be_falsy }
-    end
-
-    context 'when is not estimated and is unscheduled' do
-      let(:params) { { estimate: nil, state: 'unscheduled' } }
-
-      it { is_expected.to be_falsy }
-    end
-  end
-
   describe '#should_be_unscheduled?' do
     subject { state_ensurement.should_be_unscheduled?(params) }
 

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -21,7 +21,7 @@ describe StoryOperations do
 
       Story::ESTIMABLE_TYPES.each do |story_type|
         context "a #{story_type} story" do
-          it 'keep story state unscheduled' do
+          it 'keeps the story state unscheduled' do
             story.attributes = { state: 'unscheduled', story_type: story_type, estimate: 1 }
             subject.call
             expect(story.state).to eq('unscheduled')
@@ -157,7 +157,7 @@ describe StoryOperations do
       context "when estimate #{story_type} story" do
         let(:params) { { 'estimate' => 1, 'story_type' => story_type, 'state' => 'unscheduled' } }
 
-        it 'keep story state unscheduled' do
+        it 'keeps the story state unscheduled' do
           story.state = 'unscheduled'
           subject.call
           expect(story.state).to eq('unscheduled')

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -21,10 +21,10 @@ describe StoryOperations do
 
       Story::ESTIMABLE_TYPES.each do |story_type|
         context "a #{story_type} story" do
-          it 'sets the story state as unstarted' do
+          it 'keep story state unscheduled' do
             story.attributes = { state: 'unscheduled', story_type: story_type, estimate: 1 }
             subject.call
-            expect(story.state).to eq('unstarted')
+            expect(story.state).to eq('unscheduled')
           end
         end
 
@@ -157,10 +157,10 @@ describe StoryOperations do
       context "when estimate #{story_type} story" do
         let(:params) { { 'estimate' => 1, 'story_type' => story_type, 'state' => 'unscheduled' } }
 
-        it 'sets the story state as unstarted' do
+        it 'keep story state unscheduled' do
           story.state = 'unscheduled'
           subject.call
-          expect(story.state).to eq('unstarted')
+          expect(story.state).to eq('unscheduled')
         end
       end
 


### PR DESCRIPTION
Before os this PR, one story with unscheduled state should not had estimate, now one story with unscheduled state may or may not have estimate, so with this changes in chilly bin column the stories can be estimate.