### PR TITLE
Migrate iteration service from support

### DIFF
--- a/app/api/entities/project.rb
+++ b/app/api/entities/project.rb
@@ -30,7 +30,7 @@ class Entities::Project < Entities::BaseEntity
 
   def iteration_service
     @iteration_service ||= begin
-      Central::Support::IterationService.new(
+      IterationService.new(
         object,
         current_time: Time.current
       )

--- a/app/api/v1/projects.rb
+++ b/app/api/v1/projects.rb
@@ -59,7 +59,7 @@ class V1::Projects < Grape::API
       params[:since].months.ago
 
       if project
-        iteration = Central::Support::IterationService.new(project, current_time: current_time)
+        iteration = IterationService.new(project, current_time: current_time)
       end
 
       present iteration, with: Entities::ProjectAnalysis

--- a/app/services/iteration.rb
+++ b/app/services/iteration.rb
@@ -1,0 +1,254 @@
+class IterationService
+  DAYS_IN_WEEK = (1.week / 1.day)
+  VELOCITY_ITERATIONS = 3
+  STD_DEV_ITERATIONS = 10
+  DEFAULT_VELOCITY = 10
+
+  attr_reader :project, :current_time, :backlog
+
+  delegate :start_date, :start_date=,
+    :iteration_length, :iteration_length=,
+    :iteration_start_day, :iteration_start_day=,
+    to: :project
+
+  def initialize(project, since: nil, current_time: Time.current)
+    @project = project
+    @current_time = current_time
+
+    @stories = fetch_stories!(since)
+
+    @accepted_stories = @stories.
+      select { |story| story.column == '#done' }.
+      select { |story| story.accepted_at < iteration_start_date(@current_time) }
+
+    calculate_iterations!
+    fix_owner!
+
+    @backlog = ( @stories - @accepted_stories ).sort_by(&:position)
+  end
+
+  def fetch_stories!(since = nil)
+    relation = project.stories.includes(:owned_by)
+    relation = relation.where("accepted_at > ? or accepted_at is null", since) if since
+    relation.to_a.map { |story| story.iteration_service = self; story }
+  end
+
+  def iteration_start_date(date = nil)
+    date = start_date if date.nil?
+    iteration_start_date = date.beginning_of_day
+    if start_date.wday != iteration_start_day
+      day_difference = start_date.wday - iteration_start_day
+      day_difference += DAYS_IN_WEEK if day_difference < 0
+
+      iteration_start_date -= day_difference.days
+    end
+    iteration_start_date
+  end
+
+  def iteration_number_for_date(compare_date)
+    compare_date      = compare_date.to_time if compare_date.is_a?(Date)
+    days_apart        = ( compare_date - iteration_start_date ) / 1.day
+    days_in_iteration = iteration_length * DAYS_IN_WEEK
+    ( days_apart / days_in_iteration ).floor + 1
+  end
+
+  def date_for_iteration_number(iteration_number)
+    difference = (iteration_length * DAYS_IN_WEEK) * (iteration_number - 1)
+    iteration_start_date + difference.days
+  end
+
+  def current_iteration_number
+    iteration_number_for_date(@current_time)
+  end
+
+  def calculate_iterations!
+    @accepted_stories.each do |record|
+      record.iteration_number     = iteration_number_for_date(record.accepted_at)
+      record.iteration_start_date = date_for_iteration_number(record.iteration_number)
+    end
+  end
+
+  # FIXME must figure out why the Story allows a nil owner in delivered states
+  def fix_owner!
+    @dummy_user ||= User.find_or_create_by!(username: "dummy", email: "dummy@foo.com", name: "Dummy", initials: "XX")
+    @accepted_stories.
+      select { |record| record.owned_by.nil? }.
+      each   { |record| record.owned_by = @dummy_user }
+  end
+
+  def group_by_day(range = nil)
+    @group_by_day = {}
+    @group_by_day[range] ||= begin
+      accepted = @accepted_stories
+      accepted = accepted.select  { |story| story.accepted_at >= range.first && story.accepted_at < range.last } if range
+      accepted += backlog_iterations.first.select { |story| story.accepted_at }
+      accepted = accepted.sort_by { |story| story.accepted_at }.group_by { |story| story.accepted_at.to_date }
+
+      last_key = nil
+      accepted.keys.each do |key|
+        accepted[key] = accepted[key].sum { |story| story.estimate || 0 }
+        accepted[key] += accepted[last_key] unless last_key.nil?
+        last_key = key
+      end
+
+      {}.tap do |group|
+        next_date = project.start_date
+        last_date = backlog_iterations.last.start_date + ( project.iteration_length * DAYS_IN_WEEK )
+        while next_date < last_date
+          group.merge!(next_date => accepted.fetch(next_date, group.fetch(next_date - 1.day, 0)))
+          next_date += 1.day
+        end
+      end
+    end
+  end
+
+  def group_by_iteration
+    @group_by_iteration ||= @accepted_stories.
+      group_by { |story| story.iteration_number }.
+      reduce({}) do |group, iteration|
+        group.merge(iteration.first => stories_estimates(iteration.last))
+      end
+  end
+
+  def group_by_all_iterations
+    iterations = (1...current_iteration_number).map { |num| [num, [0]] }
+
+    Hash[iterations].merge(group_by_iteration)
+  end
+
+  def stories_estimates(stories)
+    stories.map do |story|
+      if Story::ESTIMABLE_TYPES.include? story.story_type
+        story.estimate || 0
+      else
+        0
+      end
+    end
+  end
+
+  def group_by_velocity
+    @group_by_velocity ||= group_by_all_iterations.reduce({}) do |group, iteration|
+      group.merge(iteration.first => iteration.last.reduce(&:+))
+    end
+  end
+
+  def bugs_impact(stories)
+    stories.map do |story|
+      if Story::ESTIMABLE_TYPES.include? story.story_type
+        0
+      else
+        1
+      end
+    end
+  end
+
+  def group_by_bugs
+    @group_by_bugs ||= @accepted_stories.
+      group_by { |story| story.iteration_number }.
+      reduce({}) do |group, iteration|
+        group.merge(iteration.first => bugs_impact(iteration.last))
+      end.
+      reduce({}) do |group, iteration|
+        group.merge(iteration.first => iteration.last.reduce(&:+))
+      end
+  end
+
+  def velocity(number_of_iterations = VELOCITY_ITERATIONS)
+    return DEFAULT_VELOCITY if group_by_all_iterations.size.zero?
+    @velocity ||= {}
+    @velocity[number_of_iterations] ||= begin
+      number_of_iterations = group_by_all_iterations.size if number_of_iterations > group_by_all_iterations.size
+      return 1 if number_of_iterations.zero?
+
+      iterations = Statistics.slice_to_sample_size(group_by_velocity.values, number_of_iterations)
+
+      if iterations.size > 0
+        velocity = (Statistics.sum(iterations) / Statistics.total(iterations)).floor
+        velocity < 1 ? 1 : velocity
+      else
+        1
+      end
+    end
+  end
+
+  def group_by_developer
+    @group_by_developer ||= begin
+      min_iteration = @accepted_stories.map(&:iteration_number).min
+      max_iteration = @accepted_stories.map(&:iteration_number).max
+      @accepted_stories.
+        group_by { |story| story.owned_by.name }.
+        map do |owner|
+          # all multiple series must have all the same keys or they will mess the graph
+          data = (min_iteration..max_iteration).reduce({}) { |group, key| group.merge(key => 0)}
+          owner.last.group_by { |story| story.iteration_number }.
+            each do |iteration|
+              data[iteration.first] = stories_estimates(iteration.last).reduce(&:+)
+            end
+          { name: owner.first, data: data }
+        end
+    end
+  end
+
+  def backlog_iterations(velocity_value = velocity)
+    velocity_value = 1 if velocity_value < 1
+    @backlog_iterations ||= {}
+    # mimics the project.js rebuildIteration() function
+    @backlog_iterations[velocity_value] ||= begin
+      current_iteration = Iteration.new(self, current_iteration_number, velocity_value)
+      backlog_iteration = Iteration.new(self, current_iteration_number + 1, velocity_value)
+      iterations = [current_iteration, backlog_iteration]
+      @backlog.
+        select { |story| story.column != '#chilly_bin' }.
+        each do |story|
+        if current_iteration.can_take_story?(story)
+          current_iteration << story
+        else
+          if !backlog_iteration.can_take_story?(story)
+            # Iterations sometimes 'overflow', i.e. an iteration may contain a
+            # 5 point story but the project velocity is 1.  In this case, the
+            # next iteration that can have a story added is the current + 4.
+            next_number       = backlog_iteration.number + 1 + (backlog_iteration.overflows_by / velocity_value).ceil
+            backlog_iteration = Iteration.new(self, next_number, velocity_value)
+            iterations << backlog_iteration
+          end
+          backlog_iteration << story
+        end
+      end
+      iterations
+    end
+  end
+
+  def current_iteration_details
+    current_iteration = backlog_iterations.first
+    %w(started finished delivered accepted rejected).reduce({}) do |data, state|
+      data.merge(state => current_iteration.
+                 select { |story| story.state == state }.
+                 reduce(0) { |points, story| points + (story.estimate || 0) } )
+    end
+  end
+
+  def volatility(number_of_iterations = STD_DEV_ITERATIONS)
+    Statistics.volatility(group_by_velocity.values, number_of_iterations)
+  end
+
+  def standard_deviation(number_of_iterations = STD_DEV_ITERATIONS)
+    Statistics.standard_deviation(group_by_velocity.values, number_of_iterations)
+  end
+
+  # with calculate_worst = false calculates the final project date based on the average velocity for the past 3 iterations
+  # with calculate_worst = true add the standard deviation of the velocity for the past 10 iterations
+  def backlog_date(calculate_worst = false)
+    iterations            = backlog_iterations(velocity)
+    last_iteration_number = iterations.last.number
+    if calculate_worst
+      std_dev                     = Statistics.standard_deviation(group_by_velocity.values, STD_DEV_ITERATIONS)
+      ten_iterations_slice        = Statistics.slice_to_sample_size(group_by_velocity.values, STD_DEV_ITERATIONS)
+      mean_of_last_ten_iterations = Statistics.mean(ten_iterations_slice)
+      if std_dev > 0.0 && mean_of_last_ten_iterations > 0.0
+        extra_iterations            = ( std_dev * iterations.size / mean_of_last_ten_iterations ).round
+        last_iteration_number      += extra_iterations
+      end
+    end
+    [ last_iteration_number, date_for_iteration_number(last_iteration_number) + project.iteration_length.days ]
+  end
+end

--- a/spec/services/iteration_spec.rb
+++ b/spec/services/iteration_spec.rb
@@ -1,0 +1,263 @@
+require 'rails_helper'
+
+describe IterationService do
+  let(:project) { create :project,
+                  iteration_start_day: 2,
+                  iteration_length: 1,
+                  start_date: Time.zone.parse('2016-05-13') }
+  let(:service) { IterationService.new(project) }
+
+  it 'should return the start of the current iteration' do
+    expect(service.iteration_start_date).to eq(Time.zone.parse('2016/05/10'))
+  end
+
+  it 'should return the iteration number for a date' do
+    expect(service.iteration_number_for_date(Time.zone.parse('2016/08/22'))).to eq(15)
+    expect(service.iteration_number_for_date(Time.zone.parse('2016/08/23'))).to eq(16)
+  end
+
+  it 'should return the starting date of an iteration' do
+    expect(service.date_for_iteration_number(15)).to eq(Time.zone.parse('2016/08/16'))
+    expect(service.date_for_iteration_number(16)).to eq(Time.zone.parse('2016/08/23'))
+  end
+
+  context "same specs from project_spec.js/start date describe block" do
+    before do
+      project.iteration_start_day = 1
+      project.iteration_length = 1
+    end
+
+    it 'should return the start date"' do
+      # Date is a Monday, and day 1 is Monday
+      project.start_date = Time.zone.parse "2011/09/12"
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/09/12"))
+
+      # If the project start date has been explicitly set to a Thursday, but
+      # the iteration_start_day is Monday, the start date should be the Monday
+      # that immeadiatly preceeds the Thursday.
+      project.start_date = Time.zone.parse "2011/07/28"
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/07/25"))
+
+      # The same, but this time the iteration start day is 'after' the start
+      # date day, in ordinal terms, e.g. iteration start date is a Saturday,
+      # project start date is a Thursday.  The Saturday prior to the Thursday
+      # should be returned.
+      project.iteration_start_day = 6
+      expect(service.iteration_start_date).to eq(Time.zone.parse("2011/07/23"))
+
+      # If the project start date is not set, it should be considered as the
+      # first iteration start day prior to today.
+      expected_date = Time.zone.parse('2011/07/23')
+      expect(service.iteration_start_date).to eq(expected_date)
+    end
+  end
+
+  context "same specs from project_spec.js/iterations describe block" do
+    before do
+      project.iteration_start_day = 1
+      project.iteration_length = 1
+    end
+
+    it 'should get the right iteration number for a given date' do
+      # This is a Monday
+      service.start_date = Time.zone.parse("2011/07/25")
+
+      compare_date = Time.zone.parse("2011/07/25")
+      expect(service.iteration_number_for_date(compare_date)).to eq(1)
+
+      compare_date = Time.zone.parse("2011/08/01")
+      expect(service.iteration_number_for_date(compare_date)).to eq(2)
+
+      # With a 2 week iteration length, the date above will still be in
+      # iteration 1
+      service.iteration_length = 2
+      expect(service.iteration_number_for_date(compare_date)).to eq(1)
+    end
+
+    it 'should get the right iteration number for a given date' do
+      # This is a Monday
+      service.start_date = Time.zone.parse "2011/07/25"
+
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/25"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/08/22"))
+
+      service.iteration_length = 4
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/25"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/14"))
+
+      # Sunday
+      service.iteration_start_day = 0
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/24"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/13"))
+
+      # Tuesday - This should evaluate to the Tuesday before the explicitly
+      # set start date (Monday)
+      service.iteration_start_day = 2
+      expect(service.date_for_iteration_number(1)).to eq(Time.zone.parse("2011/07/19"))
+      expect(service.date_for_iteration_number(5)).to eq(Time.zone.parse("2011/11/08"))
+    end
+  end
+
+  context 'complete set of stories in many different iterations' do
+    let(:today) { Time.utc(2016, 8, 31, 12, 0, 0) }
+    let(:dummy) { create(:user, username: "dummy", email: "dummy@foo.com", name: "Dummy", initials: "XX")}
+    let(:service) { IterationService.new(project, current_time: today) }
+    before do
+      I18n.locale = :en
+      Time.zone = 'Brasilia'
+      project.update_attribute(:start_date, Time.zone.parse("2016-07-01"))
+      project.users << dummy
+
+      story_types = ['feature', 'feature', 'bug', 'feature'] # 3 times more features than bugs, in average
+
+      # it was previously using a fixed random seed of 666, but for some reason the results were not always deterministic, so fixing the exact random sequences to make sure it always pass, but it's the same as Random.new(666).rand
+      random_numbers_1 = [0, 1, 2, 0, 2, 3, 3, 2, 1, 2, 0, 0, 3, 0, 0, 0, 3, 1, 2, 1, 3, 0, 3, 0, 2, 1, 2, 2, 3, 2, 3, 1, 2, 1, 1, 0, 3, 3, 3, 0, 3, 1, 0, 2, 1, 1, 0, 3, 2, 0, 2, 1, 3, 2, 0, 0, 0, 3, 2, 2, 2, 2, 0, 1, 3, 2, 0, 3, 3, 1, 0, 3, 2, 3, 1]
+      random_numbers_2 = [3, 2, 5, 8, 8, 1, 3, 8, 1, 8, 1, 3, 1, 8, 3, 2, 1, 1, 5, 5, 1, 1, 5, 5, 3, 1, 5, 8, 5, 5, 2, 8, 8, 3, 8, 2, 5, 8, 2, 3, 3, 3, 2, 8, 1, 1, 2, 1, 8, 3, 8, 1, 8, 1, 3]
+
+      stories = []
+      65.times do |i|
+        story_type = story_types[random_numbers_1.shift]
+        estimate = story_type == 'bug' ? nil : random_numbers_2.shift
+        stories << build(:story, project: project, id: i, title: "Story #{i}", story_type: story_type, estimate: estimate, state: 'accepted', accepted_at: project.start_date + i.days, requested_by: dummy)
+      end
+      10.times do |i|
+        story_type = story_types[random_numbers_1.shift]
+        estimate = story_type == 'bug' ? nil : random_numbers_2.shift
+        stories << build(:story, project: project, id: (65 + i), title: "Story #{65 + i}", story_type: story_type, estimate: estimate, requested_by: dummy)
+      end
+
+      allow_any_instance_of(IterationService).to receive(:fetch_stories!) { stories }
+    end
+
+    it '#group_by_iteration' do
+      groups = service.group_by_iteration
+      expect(groups).to eq({1 => [3, 2, 0, 5],
+                            2 => [0, 8, 8, 0, 1, 0, 3],
+                            3 => [8, 1, 8, 1, 3, 1, 8],
+                            4 => [0, 3, 2, 1, 1, 5, 0],
+                            5 => [5, 0, 0, 1, 0, 1, 5],
+                            6 => [0, 5, 3, 1, 5, 8, 5],
+                            7 => [5, 2, 8, 8, 0, 3, 8],
+                            8 => [2, 5, 0, 8, 0, 2, 3],
+                            9 => [0, 3, 3, 2, 8]})
+    end
+
+    it '#group_by_day' do
+      groups = service.group_by_day
+      expect(groups.keys.size - 1).to eq(( (groups.keys.last.to_time - groups.keys.first.to_time) / 1.day ).to_i)
+      expect(groups.values).to eq([3, 5, 5, 10, 10, 18, 26, 26, 27, 27, 30, 38, 39, 47, 48, 51, 52, 60, 60, 63, 65, 66, 67, 72, 72, 77, 77, 77, 78, 78, 79, 84, 84, 89, 92, 93, 98, 106, 111, 116, 118, 126, 134, 134, 137, 145, 147, 152, 152, 160, 160, 162, 165, 165, 168, 171, 173, 181, 181, 181, 181, 181, 182, 183, 185, 185, 185, 185])
+    end
+
+    it '#group_by_velocity' do
+      groups = service.group_by_velocity
+      expect(groups).to eq({1=>10, 2=>20, 3=>30, 4=>12, 5=>12, 6=>27, 7=>34, 8=>20, 9=>16})
+    end
+
+    it '#group_by_bugs' do
+      groups = service.group_by_bugs
+      expect(groups).to eq({1=>1, 2=>3, 3=>0, 4=>2, 5=>3, 6=>1, 7=>1, 8=>2, 9=>1})
+    end
+
+    describe "#velocity" do
+      it 'calculate velocity from scenario' do
+        expect(service.velocity).to eq(23)
+      end
+
+      it 'assures it not bypasses zeroed iterations' do
+        allow(service).to receive(:group_by_all_iterations) { {1=>[8], 2=>[8], 3=>[0], 4=>[0], 5=>[0], 6=>[0], 7=>[0], 8=>[0], 9=>[8, 8, 8]} }
+        expect(service.velocity).to eq(8) # ( 0 + 0 + 24 ) / 3 = 8
+      end
+
+      it 'should not return less than 1' do
+        allow(service).to receive(:group_by_velocity) { {1=>0, 2=>0, 3=>0, 4=>0, 5=>0, 6=>0, 7=>0, 8=>0, 9=>0} }
+        expect(service.velocity).to eq(1)
+      end
+
+      it 'should return the default velocity' do
+        allow(service).to receive(:group_by_all_iterations) { {} }
+        expect(service.velocity).to eq(10)
+      end
+    end
+
+    it '#group_by_developer' do
+      groups = service.group_by_developer
+      expect(groups).to eq([{:name=>"Dummy", :data=>{1=>10, 2=>20, 3=>30, 4=>12, 5=>12, 6=>27, 7=>34, 8=>20, 9=>16}}])
+    end
+
+    it '#backlog_iterations' do
+      # there were 75 stories total
+      # 59 stories in the done column
+      # there are 10 in the in_progress and 6 in the backlog
+      iterations = service.backlog_iterations
+      expect(iterations.size).to eq(2)
+      expect(iterations.first.size).to eq(11)
+      expect(iterations.last.size).to eq(6)
+
+      # override velocity to simulate different iterations
+      iterations = service.backlog_iterations(10)
+      expect(iterations.size).to eq(6)
+      expect(iterations.first.size).to eq(9)
+    end
+
+    it '#current_iteration_details' do
+      iterations = service.backlog_iterations
+      current_iteration = iterations.first
+      current_iteration[-1].start
+
+      current_iteration[-2].start
+      current_iteration[-2].finish
+
+      current_iteration[-3].start
+      current_iteration[-3].finish
+      current_iteration[-3].deliver
+      current_iteration[-3].reject
+
+      current_iteration[-4].start
+      current_iteration[-4].finish
+      current_iteration[-4].deliver
+      current_iteration[-4].accept
+
+      details = service.current_iteration_details
+      expect(details).to eq({"started"=>3, "finished"=>8, "delivered"=>0, "accepted"=>4, "rejected"=>1})
+    end
+
+    it '#standard_deviation' do
+      standard_deviation = Central::Support::Statistics.standard_deviation([])
+      expect(standard_deviation).to eq(0)
+
+      # calculate for population
+      standard_deviation = Central::Support::Statistics.standard_deviation(service.group_by_velocity.values)
+      expect("%.4f" % standard_deviation).to eq("8.0890")
+
+      # calculate for sample (N - 1) for correction
+      standard_deviation = Central::Support::Statistics.standard_deviation(service.group_by_velocity.values, 8)
+      expect("%.4f" % standard_deviation).to eq("8.2278")
+
+      # last 3 iterations
+      standard_deviation = Central::Support::Statistics.standard_deviation(service.group_by_velocity.values, 3)
+      expect("%.4f" % standard_deviation).to eq("9.4516")
+    end
+
+    it '#volatility' do
+      volatility = service.volatility(8) # sample, 8 < 9
+      expect("%.4f" % volatility).to eq("0.3849")
+
+      volatility = service.volatility # population (no variance correction)
+      expect("%.4f" % volatility).to eq("0.3816")
+
+      # must return 0 if there is no accepted stories on the project
+      allow(service).to receive(:group_by_velocity) { Hash[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+      expect(service.volatility).to eq(0)
+    end
+
+    it '#backlog_date' do
+      iteration_number, iteration_date = service.backlog_date
+      expect(iteration_number).to eq(11)
+      expect(iteration_date).to eq(Time.zone.parse("2016/09/07"))
+
+      iteration_number, iteration_date = service.backlog_date(true)
+      expect(iteration_number).to eq(12)
+      expect(iteration_date).to eq(Time.zone.parse("2016/09/14"))
+    end
+  end
+end


### PR DESCRIPTION
This is the migrating the iteration service class from cm42-central-support to cm42-central.

