### PR TITLE
Migrate Discord from cm42-central-support

### DIFF
--- a/app/services/integrations/discord/helper.rb
+++ b/app/services/integrations/discord/helper.rb
@@ -1,0 +1,21 @@
+require 'uri'
+
+module Integrations
+  module Discord
+    module Helper
+      def send_discord(integration, message)
+        Integrations::Discord::Service.send(real_private_uri(integration.data['private_uri']),
+          integration.data['bot_username'],
+          message)
+      end
+
+      private
+
+      def real_private_uri(private_uri)
+        return ENV[private_uri] if private_uri.starts_with? 'INTEGRATION_URI'
+
+        private_uri
+      end
+    end
+  end
+end

--- a/app/services/integrations/discord/service.rb
+++ b/app/services/integrations/discord/service.rb
@@ -1,0 +1,48 @@
+require 'net/http'
+
+module Integrations
+  module Discord
+    class Service
+      def self.send(private_uri, bot_username, message)
+        self.new(private_uri, bot_username).send(message)
+      end
+
+      def initialize(private_uri, bot_username = 'marvin')
+        @private_uri = URI.parse(private_uri)
+        @bot_username = bot_username
+      end
+
+      def send(text)
+        if Rails.env.development?
+          Rails.logger.debug('NOT SENDING TO OUTSIDE INTEGRATION!')
+          Rails.logger.debug("URL: #{@private_uri}")
+          Rails.logger.debug("Payload: #{payload(text)}")
+        else
+          Net::HTTP.start(@private_uri.host, @private_uri.port, use_ssl: true) do |https|
+            request = Net::HTTP::Post.new(
+              @private_uri.request_uri, 'Content-Type': 'application/json'
+            )
+            request.body = payload(text).to_json
+
+            https.request(request)
+          end
+        end
+      end
+
+      def payload(text, truncate_at = 2000)
+        text = { description: text } if text.is_a?(String)
+
+        embeds = [text].flatten.each do |embed|
+          next if embed[:description].blank?
+
+          embed[:description] = embed[:description].truncate(truncate_at)
+        end
+
+        {
+          username: @bot_username,
+          embeds: embeds
+        }
+      end
+    end
+  end
+end

--- a/app/workers/integration_worker.rb
+++ b/app/workers/integration_worker.rb
@@ -1,6 +1,6 @@
 class IntegrationWorker
   include Sidekiq::Worker
-  include Central::Support::DiscordHelper
+  include Integrations::Discord::Helper
   include Integrations::Mattermost::Helper
   include Central::Support::SlackHelper
 

--- a/spec/services/discord_service_spec.rb
+++ b/spec/services/discord_service_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe Integrations::Discord::Service do
+  let(:discord) { described_class.new('http://foo.com', 'bot') }
+
+  context '#payload' do
+    it 'returns a params formatted payload when string' do
+      expect(discord.payload('Hello World'))
+        .to eq(username: 'bot', embeds: [{ description: 'Hello World' }])
+    end
+
+    it 'returns a params formatted payload when embed' do
+      expect(discord.payload(description: 'test', color: 123))
+        .to eq(username: 'bot', embeds: [{ description: 'test', color: 123 }])
+    end
+
+    it 'returns a params formatted and truncated payload when string' do
+      expect(discord.payload('lorem ipsum dolor', 5))
+        .to eq(username: 'bot', embeds: [{ description: 'lo...' }])
+    end
+
+    it 'returns a params formatted and truncated payload when embed' do
+      expect(discord.payload({ description: 'lorem ipsum dolor', color: 123 }, 10))
+        .to eq(username: 'bot', embeds: [{ description: 'lorem i...', color: 123 }])
+    end
+  end
+
+  context '#send' do
+    let(:http) { double :http }
+
+    it 'triggers a HTTP POST to send payload' do
+      expect(Rails.env).to receive(:development?).and_return(false)
+      expect(Net::HTTP).to receive(:start).and_yield(http)
+      expect(http).to receive(:request)
+
+      discord.send('hello')
+    end
+  end
+end


### PR DESCRIPTION
This pr is migrating the Discord class and DiscordHelper tests, from cm42-central-support to cm42-central.