### PR TITLE
Add Code Climate Test Reporter config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ addons:
     paths:
       - $(ls -d -1 $PWD/tmp/capybara/* | tr "\n" ":")
 env:
-  - "DB=postgresql"
+  global:
+    - "DB=postgresql"
+    - CC_TEST_REPORTER_ID=9eb33c5afdf03c410afd7706824322e6bc10d0a6911c154a7d2a2e8671f1528f
 before_install:
   - nvm install 10.17.0
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,12 @@ before_script:
   - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
   - "export DISPLAY=:99.0"
   - "bundle exec rake --trace fulcrum:setup db:setup"
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 rvm:
   - 2.6.0
 script:
   - "bundle exec rake travis"
-  - "bundle exec codeclimate-test-reporter"
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'selenium-webdriver'

--- a/Gemfile
+++ b/Gemfile
@@ -76,16 +76,17 @@ group :production do
 end
 
 group :test do
-  gem 'rails-controller-testing'
   gem 'capybara'
   gem 'capybara-screenshot'
+  gem 'coveralls', require: false
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'selenium-webdriver'
-  gem 'rspec-retry'
+  gem 'rails-controller-testing'
   gem 'rspec-activemodel-mocks'
   gem 'rspec-its'
   gem 'rspec-rails'
+  gem 'rspec-retry'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     cloudinary (1.1.7)
       aws_cf_signer
       rest-client
-    codeclimate-test-reporter (1.0.9)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -571,7 +569,6 @@ DEPENDENCIES
   chartkick
   chronic
   cloudinary
-  codeclimate-test-reporter
   coffee-rails
   compass-rails
   configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,12 @@ GEM
     configuration (1.3.4)
     connection_pool (2.2.2)
     cookiejar (0.3.3)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -509,6 +515,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -517,6 +525,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.9)
     timecop (0.9.1)
+    tins (1.22.2)
     transitions (0.1.13)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -572,6 +581,7 @@ DEPENDENCIES
   coffee-rails
   compass-rails
   configuration
+  coveralls
   dalli
   database_cleaner
   devise

--- a/spec/support/coveralls.rb
+++ b/spec/support/coveralls.rb
@@ -1,0 +1,3 @@
+require 'coveralls'
+
+Coveralls.wear!


### PR DESCRIPTION
### Description

This PR is removing the [codeclimate-test-reporter](https://github.com/Codeminer42/cm42-central/blob/master/Gemfile#L82) deprecated gem, and adding the [Code Climate Test Reporter](https://github.com/codeclimate/test-reporter/) instead.