### PR TITLE
Changelog to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.5.0] 2020-01-17
+
 ### Removed
 - Rewire and Rewire Webpack
 - Inject loader
@@ -469,7 +471,7 @@ and CVE-2018-14567)
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
-[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/Codeminer42/cm42-central/compare/v2.5.0...HEAD
 [1.0.0]: https://github.com/Codeminer42/cm42-central/tree/v1.0.0
 [1.1.0]: https://github.com/Codeminer42/cm42-central/tree/v1.1.0
 [1.1.1]: https://github.com/Codeminer42/cm42-central/tree/v1.1.1
@@ -507,3 +509,4 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [2.2.0]: https://github.com/Codeminer42/cm42-central/tree/v2.2.0
 [2.3.0]: https://github.com/Codeminer42/cm42-central/tree/v2.3.0
 [2.4.0]: https://github.com/Codeminer42/cm42-central/tree/v2.4.0
+[2.5.0]: https://github.com/Codeminer42/cm42-central/tree/v2.5.0


### PR DESCRIPTION
### Removed
- Rewire and Rewire Webpack
- Inject loader
- Karma and all dependencies related

### Changed
- [ V2 ] When story is accepted it has a different background color.
- Unscheduled stories may or not may have a estimate.
- Chilly Bin column have stories with or no estimate.
- Migrate all the javascripts tests from jasmine to jest.

### Update
- Front-End Dependencies
- NodeJS from 9.11.2 to 10.17.0
- Webpack Dev Server from 3.1.14 to 3.9.0

### Added
- babel-jest and @testing-library/jest-dom
- [ V2 ] Dialog confirmation when story state is changed in expanded shape.
- [ V2 ] Spinner when project is loading.
- [ V2 ] User mention.
- [ V2 ] Button to reverse story flow.
- [ V2 ] Actor in history of changes.
- [ V2 ] Buttons to show and hide columns.

### Fixed
- [ V2 ] Internationalization date.
- [ V2 ] Sprints calc bug.