### PR TITLE
New position logic for drag and drop beta version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Fixed
 - Bug when change release date of story.
 
+### Added
+- New position column to Story
+
+### Changed
+- Change drag and drop logic in beta version
+
 ## [2.6.0] 2020-03-11
 
 ### Added

--- a/app/assets/javascripts/actions/actionTypes.js
+++ b/app/assets/javascripts/actions/actionTypes.js
@@ -22,6 +22,7 @@ export default keyMirror({
   RECEIVE_HISTORY_ERROR: null,
   CLOSE_HISTORY: null,
   UPDATE_STORY_SUCCESS: null,
+  SORT_STORIES_SUCCESS: null,
   STORY_FAILURE: null,
   SET_LOADING_STORY: null,
   ADD_TASK: null,

--- a/app/assets/javascripts/actions/story.js
+++ b/app/assets/javascripts/actions/story.js
@@ -58,6 +58,12 @@ export const updateStorySuccess = (story, from) => ({
   from
 });
 
+export const sortStoriesSuccess = (stories, from) => ({
+  type: actionTypes.SORT_STORIES_SUCCESS,
+  stories,
+  from
+});
+
 export const optimisticallyUpdate = (story, from) => ({
   type: actionTypes.OPTIMISTICALLY_UPDATE,
   story,
@@ -183,11 +189,11 @@ export const dragDropStory = (storyId, projectId, newAttributes, from) =>
     try {
       dispatch(optimisticallyUpdate(newStory, from));
 
-      const updatedStory = await Story.update(newStory, projectId);
+      const updatedStories = await Story.sort(newStory);
 
       await wait(300);
 
-      return dispatch(updateStorySuccess(updatedStory, from));
+      return dispatch(sortStoriesSuccess(updatedStories, from));
     }
     catch (error) {
       dispatch(sendErrorNotification(error))

--- a/app/assets/javascripts/actions/story.js
+++ b/app/assets/javascripts/actions/story.js
@@ -190,7 +190,7 @@ export const dragDropStory = (storyId, projectId, newAttributes, from) =>
       dispatch(optimisticallyUpdate(newStory, from));
 
       const updatedStories = await Story.sort(newStory);
-      console.log(updatedStories)
+
       await wait(300);
 
       return dispatch(sortStoriesSuccess(updatedStories, from));

--- a/app/assets/javascripts/actions/story.js
+++ b/app/assets/javascripts/actions/story.js
@@ -190,7 +190,7 @@ export const dragDropStory = (storyId, projectId, newAttributes, from) =>
       dispatch(optimisticallyUpdate(newStory, from));
 
       const updatedStories = await Story.sort(newStory);
-
+      console.log(updatedStories)
       await wait(300);
 
       return dispatch(sortStoriesSuccess(updatedStories, from));

--- a/app/assets/javascripts/actions/story.js
+++ b/app/assets/javascripts/actions/story.js
@@ -189,10 +189,9 @@ export const dragDropStory = (storyId, projectId, newAttributes, from) =>
     try {
       dispatch(optimisticallyUpdate(newStory, from));
 
-      const updatedStories = await Story.sort(newStory);
+      const updatedStories = await Story.updatePosition(newStory);
 
       await wait(300);
-
       return dispatch(sortStoriesSuccess(updatedStories, from));
     }
     catch (error) {

--- a/app/assets/javascripts/components/projects/ProjectBoard.js
+++ b/app/assets/javascripts/components/projects/ProjectBoard.js
@@ -10,7 +10,7 @@ import { CHILLY_BIN, DONE, BACKLOG, EPIC } from "../../models/beta/column";
 import PropTypes from "prop-types";
 import {
   canCloseColumn,
-  getNewPosition,
+  getPositions,
   getNewSprints,
   getNewState,
   moveStory,
@@ -83,13 +83,14 @@ export const ProjectBoard = ({
     if (isSameColumn && sourceIndex === destinationIndex) return;
     if (!dropColumn) return;
 
-    const newPosition = getNewPosition(
+    const [position, newPosition] = getPositions(
       destinationIndex,
       sourceIndex,
       destinationArray,
       isSameColumn,
       dragStory.state,
     );
+
 
     const newStories = moveStory(
       sourceArray,
@@ -112,7 +113,8 @@ export const ProjectBoard = ({
     const newState = getNewState(isSameColumn, dropColumn, dragStory.state);
 
     return dragDropStory(dragStory.id, dragStory.projectId, {
-      position: newPosition,
+      position,
+      newPosition,
       state: newState,
     });
   };

--- a/app/assets/javascripts/components/projects/ProjectBoard.js
+++ b/app/assets/javascripts/components/projects/ProjectBoard.js
@@ -17,7 +17,7 @@ import {
   getSprintColumn,
   dragStory
 } from '../../models/beta/projectBoard';
-import { historyStatus, columns } from 'libs/beta/constants';
+import { historyStatus, columns, storyTypes } from 'libs/beta/constants';
 import StoryPropTypes from '../shapes/story';
 import ProjectBoardPropTypes from '../shapes/projectBoard';
 import Notifications from '../Notifications';
@@ -82,6 +82,7 @@ export const ProjectBoard = ({
 
     if (isSameColumn && sourceIndex === destinationIndex) return;
     if (!dropColumn) return;
+    if (!isSameColumn && dragStory.storyType === storyTypes.FEATURE && !dragStory.estimate) return;
 
     const [position, newPosition] = getPositions(
       destinationIndex,

--- a/app/assets/javascripts/models/beta/projectBoard.js
+++ b/app/assets/javascripts/models/beta/projectBoard.js
@@ -68,7 +68,7 @@ export const toggleColumn = (projectBoard, column, callback) => {
 }
 
 // Drag And drop utils
-const calculatePositions = ({ aboveStory = {}, belowStory = {}, storyState }) => {
+const calculatePositions = (aboveStory, belowStory, storyState) => {
   const aboveStoryState = aboveStory?.state;
   const belowStoryState = belowStory?.state;
   const aboveStoryPosition = Number(aboveStory?.position);
@@ -101,18 +101,11 @@ export const getPositions = (
     return [1, 1];
   }
 
-  const calculateArguments = {
-    aboveStory: storiesArray[destinationIndex],
-    belowStory: storiesArray[destinationIndex + 1],
-    storyState: storyState
-  };
-
   if (!isSameColumn || sourceIndex > destinationIndex) {
-    calculateArguments.aboveStory = storiesArray[destinationIndex - 1];
-    calculateArguments.belowStory = storiesArray[destinationIndex];
+    return calculatePositions(storiesArray[destinationIndex - 1], storiesArray[destinationIndex], storyState);
   }
 
-  return calculatePositions(calculateArguments);
+  return calculatePositions(storiesArray[destinationIndex], storiesArray[destinationIndex + 1], storyState);
 };
 
 // reorder the array

--- a/app/assets/javascripts/models/beta/projectBoard.js
+++ b/app/assets/javascripts/models/beta/projectBoard.js
@@ -68,13 +68,13 @@ export const toggleColumn = (projectBoard, column, callback) => {
 }
 
 // Drag And drop utils
-const calculatePositions = (aboveStory, belowStory, storyState) => {
-  const aboveStoryState = aboveStory?.state;
-  const belowStoryState = belowStory?.state;
-  const aboveStoryPosition = Number(aboveStory?.position);
-  const belowStoryPosition = Number(belowStory?.position);
-  const aboveStoryNewPosition = aboveStory?.newPosition;
-  const belowStoryNewPosition = belowStory?.newPosition;
+const calculatePositions = (aboveStory = {}, belowStory = {}, storyState = {}) => {
+  const aboveStoryState = aboveStory.state;
+  const belowStoryState = belowStory.state;
+  const aboveStoryPosition = Number(aboveStory.position);
+  const belowStoryPosition = Number(belowStory.position);
+  const aboveStoryNewPosition = aboveStory.newPosition;
+  const belowStoryNewPosition = belowStory.newPosition;
 
   const isFirstStory = !aboveStoryState;
   const isLastStory = !belowStoryState;

--- a/app/assets/javascripts/models/beta/projectBoard.js
+++ b/app/assets/javascripts/models/beta/projectBoard.js
@@ -83,9 +83,8 @@ const calculatePositions = (aboveStory = {}, belowStory = {}, storyState = {}) =
 
   // return [position, newPosition]
   if (isFirstStory) return [belowStoryPosition - 1, 1];
-  if (isLastStory) return [aboveStoryPosition + 1, aboveStoryNewPosition + 1];
-  if (isLastStoryInSameState) return [aboveStoryPosition + 1, aboveStoryNewPosition + 1];
   if (isFirstStoryInSameState) return [belowStoryPosition - 1, belowStoryNewPosition - 1];
+  if (isLastStory || isLastStoryInSameState) return [aboveStoryPosition + 1, aboveStoryNewPosition + 1];
 
   return [(belowStoryPosition + aboveStoryPosition) / 2, aboveStoryNewPosition + 1];
 }

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -22,8 +22,8 @@ export const needConfirmation = story =>
   story.state === status.RELEASE
 
 export const comparePosition = (a, b) => {
-  const positionA = parseFloat(a.position);
-  const positionB = parseFloat(b.position);
+  const positionA = parseInt(a.newPosition);
+  const positionB = parseInt(b.newPosition);
 
   return compareValues(positionA, positionB);
 };
@@ -106,6 +106,16 @@ export const states = [
 
 export const findById = (stories, id) => {
   return stories.find(story => story.id === id)
+}
+
+export const sort = async (story) => {
+  const newStory = serialize(story);
+
+  const { data } = await httpService.post('/beta/stories/sort', { story: newStory });
+
+  const deserializedData = data.map((item) => (deserialize(item.story)));
+
+  return deserializedData;
 }
 
 export const update = async (story, projectId, options) => {
@@ -374,6 +384,7 @@ const emptyStory = {
   createdAt: '',
   updatedAt: '',
   position: '',
+  newPosition: null,
   labels: [],
   requestedByName: '',
   ownedByName: null,

--- a/app/assets/javascripts/models/beta/story.js
+++ b/app/assets/javascripts/models/beta/story.js
@@ -22,8 +22,8 @@ export const needConfirmation = story =>
   story.state === status.RELEASE
 
 export const comparePosition = (a, b) => {
-  const positionA = parseInt(a.newPosition);
-  const positionB = parseInt(b.newPosition);
+  const positionA = a.newPosition;
+  const positionB = b.newPosition;
 
   return compareValues(positionA, positionB);
 };
@@ -108,10 +108,10 @@ export const findById = (stories, id) => {
   return stories.find(story => story.id === id)
 }
 
-export const sort = async (story) => {
-  const newStory = serialize(story);
+export const updatePosition = async (story) => {
+  const serializedStory = serialize(story);
 
-  const { data } = await httpService.post('/beta/stories/sort', { story: newStory });
+  const { data } = await httpService.post(`/beta/stories/${story.id}/position`, { story: serializedStory });
 
   const deserializedData = data.map((item) => (deserialize(item.story)));
 
@@ -119,19 +119,19 @@ export const sort = async (story) => {
 }
 
 export const update = async (story, projectId, options) => {
-  const newStory = serialize(story);
+  const serializedStory = serialize(story);
 
   const { data } = await httpService
-    .put(`/projects/${projectId}/stories/${story.id}`, { story: newStory });
+    .put(`/projects/${projectId}/stories/${story.id}`, { story: serializedStory });
 
   return deserialize(data.story, options);
 };
 
 export const post = async (story, projectId) => {
-  const newStory = serialize(story);
+  const serializedStory = serialize(story);
 
   const { data } = await httpService
-    .post(`/projects/${projectId}/stories`, { story: newStory });
+    .post(`/projects/${projectId}/stories`, { story: serializedStory });
 
   return deserialize(data.story);
 };

--- a/app/assets/javascripts/reducers/stories.js
+++ b/app/assets/javascripts/reducers/stories.js
@@ -74,6 +74,18 @@ const storiesReducer = (state = initialState, action) => {
             addNewAttributes(story, { ...action.story, needsToSave: false, loading: false })
           ))
       })
+    case actionTypes.SORT_STORIES_SUCCESS:
+      return allScopes(state, null, stories => {
+        return stories.map((story) => {
+          for(let i = 0; i < action.stories.length; i+=1) {
+            const incomingStory = action.stories[i];
+            if (incomingStory.id === story.id) {
+              return addNewAttributes(story, { ...incomingStory, needsToSave: false, loading: false })
+            }
+          }
+          return story;
+        })
+      })
     case actionTypes.OPTIMISTICALLY_UPDATE:
       return allScopes(state, action.story.id, stories => {
         return stories.map(
@@ -81,7 +93,7 @@ const storiesReducer = (state = initialState, action) => {
             const newStory = setLoadingValue(action.story, true);
             return addNewAttributes(story, { ...newStory, needsToSave: false });
           }
-          ))
+        ))
       })
     case actionTypes.STORY_FAILURE:
       return {

--- a/app/assets/javascripts/reducers/stories.js
+++ b/app/assets/javascripts/reducers/stories.js
@@ -77,13 +77,11 @@ const storiesReducer = (state = initialState, action) => {
     case actionTypes.SORT_STORIES_SUCCESS:
       return allScopes(state, null, stories => {
         return stories.map((story) => {
-          for(let i = 0; i < action.stories.length; i+=1) {
-            const incomingStory = action.stories[i];
-            if (incomingStory.id === story.id) {
-              return addNewAttributes(story, { ...incomingStory, needsToSave: false, loading: false })
-            }
-          }
-          return story;
+          const editingStory = action.stories.find((incomingStory) => story.id === incomingStory.id)
+
+          return editingStory
+            ? addNewAttributes(story, { ...editingStory, needsToSave: false, loading: false })
+            : story
         })
       })
     case actionTypes.OPTIMISTICALLY_UPDATE:

--- a/app/controllers/beta/stories_controller.rb
+++ b/app/controllers/beta/stories_controller.rb
@@ -1,8 +1,8 @@
 class Beta::StoriesController < ApplicationController
   before_action :set_project_and_story
-  def sort
+  def position
     authorize Story
-    stories = Beta::SortStories.new(allowed_params).call
+    stories = Beta::SortStories.new(@story, allowed_params).call
     render json: stories
   end
 

--- a/app/controllers/beta/stories_controller.rb
+++ b/app/controllers/beta/stories_controller.rb
@@ -1,0 +1,18 @@
+class Beta::StoriesController < ApplicationController
+  before_action :set_project_and_story
+  def sort
+    authorize Story
+    stories = Beta::SortStories.new(allowed_params).call
+    render json: stories
+  end
+
+  private
+  def allowed_params
+    params.require(:story).permit(:position, :new_position, :id, :state, :project_id)
+  end
+
+  def set_project_and_story
+    @project = policy_scope(Project).find(allowed_params[:project_id])
+    @story   = policy_scope(Story).find(allowed_params[:id])
+  end
+end

--- a/app/controllers/beta/stories_controller.rb
+++ b/app/controllers/beta/stories_controller.rb
@@ -7,6 +7,7 @@ class Beta::StoriesController < ApplicationController
   end
 
   private
+
   def allowed_params
     params.require(:story).permit(:position, :new_position, :id, :state, :project_id)
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -103,7 +103,7 @@ has_attachments :documents,
     title release_date accepted_at created_at updated_at delivered_at description
     project_id story_type owned_by_id requested_by_id
     owned_by_name owned_by_initials requested_by_name estimate
-    state position id labels
+    state position id labels new_position
   ].freeze
 
   JSON_METHODS = %w[errors notes documents tasks].freeze

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -27,6 +27,10 @@ class StoryPolicy < ApplicationPolicy
     update?
   end
 
+  def position?
+    update?
+  end
+
   def backlog?
     update?
   end

--- a/app/services/beta/sort_stories.rb
+++ b/app/services/beta/sort_stories.rb
@@ -1,0 +1,35 @@
+class Beta::SortStories
+  def initialize(sort_params)
+    @story = Story.find(sort_params[:id])
+    @new_position = sort_params[:new_position]
+    @new_state = sort_params[:state]
+    @position = sort_params[:position]
+  end
+
+  def call
+    @story.update(new_position: @new_position, state: @new_state, position: @position)
+    update_stories_positions
+    stories
+  end
+
+  private
+
+  def stories_to_update
+    stories.where.not(id: @story.id)
+  end
+
+  def update_stories_positions
+    stories_to_update.update_all("new_position = new_position + 1")
+  end
+
+  def stories
+    case @new_state
+    when "started", "finished", "delivered"
+      @story.project.stories.in_progress.where("new_position >= ?", @new_position)
+    when "unstarted"
+      @story.project.stories.backlog.where("new_position >= ?", @new_position)
+    when "unscheduled"
+      @story.project.stories.chilly_bin.where("new_position >= ?", @new_position)
+    end
+  end
+end

--- a/app/services/beta/sort_stories.rb
+++ b/app/services/beta/sort_stories.rb
@@ -1,18 +1,22 @@
 class Beta::SortStories
-  def initialize(sort_params)
-    @story = Story.find(sort_params[:id])
+  def initialize(story, sort_params)
+    @story = story
     @new_position = sort_params[:new_position]
     @new_state = sort_params[:state]
     @position = sort_params[:position]
   end
 
   def call
-    @story.update(new_position: @new_position, state: @new_state, position: @position)
+    update_current_story
     update_stories_positions
     stories
   end
 
   private
+
+  def update_current_story
+    @story.update(new_position: @new_position, state: @new_state, position: @position)
+  end
 
   def stories_to_update
     stories.where.not(id: @story.id)

--- a/app/services/beta/sort_stories.rb
+++ b/app/services/beta/sort_stories.rb
@@ -23,17 +23,17 @@ class Beta::SortStories
   end
 
   def update_stories_positions
-    stories_to_update.update_all("new_position = new_position + 1")
+    stories_to_update.update_all('new_position = new_position + 1')
   end
 
   def stories
     case @new_state
-    when "started", "finished", "delivered"
-      @story.project.stories.in_progress.where("new_position >= ?", @new_position)
-    when "unstarted"
-      @story.project.stories.backlog.where("new_position >= ?", @new_position)
-    when "unscheduled"
-      @story.project.stories.chilly_bin.where("new_position >= ?", @new_position)
+    when 'started', 'finished', 'delivered'
+      @story.project.stories.in_progress.where('new_position >= ?', @new_position)
+    when 'unstarted'
+      @story.project.stories.backlog.where('new_position >= ?', @new_position)
+    when 'unscheduled'
+      @story.project.stories.chilly_bin.where('new_position >= ?', @new_position)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,8 +74,8 @@ Rails.application.routes.draw do
     resources :projects, only: :show
     resources :project_boards, only: :show
     resources :stories, only: [] do
-      collection do
-        post :sort
+      member do
+        post :position
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,11 @@ Rails.application.routes.draw do
   namespace :beta do
     resources :projects, only: :show
     resources :project_boards, only: :show
+    resources :stories, only: [] do
+      collection do
+        post :sort
+      end
+    end
   end
 
   resources :tag_groups

--- a/db/migrate/20210201140311_add_new_position_to_story.rb
+++ b/db/migrate/20210201140311_add_new_position_to_story.rb
@@ -1,0 +1,8 @@
+class AddNewPositionToStory < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stories, :new_position, :integer, null: true
+  end
+  def down
+    remove_column :stories, :new_position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_14_123043) do
+ActiveRecord::Schema.define(version: 2021_02_01_140311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 2019_01_14_123043) do
     t.date "release_date"
     t.datetime "delivered_at"
     t.string "branch"
+    t.integer "new_position"
   end
 
   create_table "tag_groups", id: :serial, force: :cascade do |t|

--- a/lib/tasks/populate_newposition.rake
+++ b/lib/tasks/populate_newposition.rake
@@ -6,9 +6,9 @@ task populate_newposition: :environment do
     new_position = 1
     stories.each_with_index do |story|
       story.update_column(:new_position, new_position)
-      new_position = new_position + 1
+      new_position += 1
     end
-    puts "✓ Updated #{stories.length()} stories.\n\n"
+    puts "✓ Updated #{stories.length} stories.\n\n"
   end
 
   Project.find_each do |project|

--- a/lib/tasks/populate_newposition.rake
+++ b/lib/tasks/populate_newposition.rake
@@ -1,0 +1,17 @@
+desc 'Populate new position column'
+task populate_newposition: :environment do
+  def update_column(stories)
+    new_position = 1
+    stories.each_with_index do |story|
+      story.update_column(:new_position, new_position)
+      new_position = new_position + 1
+    end
+  end
+
+  Project.find_each do |project|
+    update_column(project.stories.chilly_bin.order(:position))
+    update_column(project.stories.backlog.order(:position))
+    update_column(project.stories.in_progress.order(:position))
+    update_column(project.stories.done.order(:position))
+  end
+end

--- a/lib/tasks/populate_newposition.rake
+++ b/lib/tasks/populate_newposition.rake
@@ -1,17 +1,26 @@
 desc 'Populate new position column'
 task populate_newposition: :environment do
+  puts "RUNNING TASK: populate_newposition\n\n"
+
   def update_column(stories)
     new_position = 1
     stories.each_with_index do |story|
       story.update_column(:new_position, new_position)
       new_position = new_position + 1
     end
+    puts "✓ Updated #{stories.length()} stories.\n\n"
   end
 
   Project.find_each do |project|
+    puts 'Updating chilly_bin column...'
     update_column(project.stories.chilly_bin.order(:position))
+    puts 'Updating backlog column...'
     update_column(project.stories.backlog.order(:position))
+    puts 'Updating in_progress column...'
     update_column(project.stories.in_progress.order(:position))
+    puts 'Updating done column...'
     update_column(project.stories.done.order(:position))
   end
+
+  puts 'Task done.'
 end

--- a/spec/cypress/integration/dragAndDrop_spec.js
+++ b/spec/cypress/integration/dragAndDrop_spec.js
@@ -10,9 +10,11 @@ describe("DragAndDrop", () => {
   beforeEach(() => {
     cy.app("clean"); //clean the db
     cy.app("load_seed"); // load the seeds
+    cy.exec("bundle exec rake populate_newposition");
     cy.loginWith("foo@bar.com", "asdfasdf");
 
     cy.aliasUpdateStory();
+    cy.aliasUpdateStoryPosition();
   });
 
   describe("Drag and drop in same column", () => {
@@ -30,7 +32,7 @@ describe("DragAndDrop", () => {
       // reorder
       cy.moveStory("@first", Keys.arrowDown, Keys.space);
 
-      cy.waitUpdateStory(200);
+      cy.waitUpdateStoryPosition(200);
 
       // wait loading story
       cy.wait(300);
@@ -54,7 +56,7 @@ describe("DragAndDrop", () => {
       // reorder
       cy.moveStory("@second", Keys.arrowUp, Keys.space);
 
-      cy.waitUpdateStory(200);
+      cy.waitUpdateStoryPosition(200);
 
       // wait loading story
       cy.wait(300);
@@ -83,7 +85,7 @@ describe("DragAndDrop", () => {
         .as("drag-story")
         .moveStory("@drag-story", Keys.arrowLeft, Keys.space);
 
-      cy.waitUpdateStory(200);
+      cy.waitUpdateStoryPosition(200);
 
       // check new order
       cy.getDraggablesFromColumn(backlog).should("not.contain", dragStory);
@@ -112,7 +114,7 @@ describe("DragAndDrop", () => {
           .as("drag-element")
           .moveStory("@drag-element", Keys.arrowRight, Keys.space);
 
-        cy.waitUpdateStory(200);
+        cy.waitUpdateStoryPosition(200);
 
         // check new order
         cy.getDraggablesFromColumn(chillyBin).should("not.contain", dragStory);
@@ -133,7 +135,7 @@ describe("DragAndDrop", () => {
           .as("drag-element")
           .moveStory("@drag-element", Keys.arrowRight, Keys.space);
 
-        cy.waitUpdateStory(200);
+        cy.waitUpdateStoryPosition(200);
 
         // check new order
         cy.getDraggablesFromColumn(chillyBin).should("not.contain", dragStory);
@@ -153,8 +155,6 @@ describe("DragAndDrop", () => {
           .first()
           .as("drag-element")
           .moveStory("@drag-element", Keys.arrowRight, Keys.space);
-
-        cy.waitUpdateStory(200);
 
         // check new order
         cy.getDraggablesFromColumn(chillyBin).should("contain", dragStory);

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -41,3 +41,13 @@ Cypress.Commands.add('waitUpdateStory', (httpCode = 200) => {
   cy.wait('@update-story')
     .should('have.property', 'status', httpCode);
 })
+
+Cypress.Commands.add('aliasUpdateStoryPosition', () => {
+  cy.server();
+  cy.route('POST', '/beta/stories/**').as('update-story-position');
+})
+
+Cypress.Commands.add('waitUpdateStoryPosition', (httpCode = 200) => {
+  cy.wait('@update-story-position')
+    .should('have.property', 'status', httpCode);
+})

--- a/spec/javascripts/actions/story_spec.js
+++ b/spec/javascripts/actions/story_spec.js
@@ -272,7 +272,7 @@ describe('Story Actions', () => {
     it('calls Story.sortStoriesSuccess with new position', async () => {
       const FakeStory = {
         findById: sinon.stub().returns(updatedStory),
-        sort: sinon.stub().resolves(updatedStories),
+        updatePosition: sinon.stub().resolves(updatedStories),
         isNew: sinon.stub().returns(false),
         withScope: sinon.stub().returns([story]),
         addNewAttributes: sinon.stub().returns(story)
@@ -297,7 +297,7 @@ describe('Story Actions', () => {
 
       const FakeStory = {
         findById: sinon.stub().returns(updatedStory),
-        sort: sinon.stub().rejects(error),
+        updatePosition: sinon.stub().rejects(error),
         isNew: sinon.stub().returns(false),
         withScope: sinon.stub().returns([story]),
         addNewAttributes: sinon.stub().returns(story)

--- a/spec/javascripts/actions/story_spec.js
+++ b/spec/javascripts/actions/story_spec.js
@@ -265,29 +265,30 @@ describe('Story Actions', () => {
 
   describe('dragDropStory', () => {
     const story = storyFactory();
-    const updatedStory = { ...story, position: 3.54 };
+    const updatedStories = [{ ...story, newPosition: 4, id: 42 }, { ...story, newPosition: 6, id: 43 }]
+    const updatedStory = { ...story, newPosition: 4 };
     const from = 1;
 
-    it('calls Story.updateStorySuccess with new position', async () => {
+    it('calls Story.sortStoriesSuccess with new position', async () => {
       const FakeStory = {
         findById: sinon.stub().returns(updatedStory),
-        update: sinon.stub().resolves(updatedStory),
+        sort: sinon.stub().resolves(updatedStories),
         isNew: sinon.stub().returns(false),
         withScope: sinon.stub().returns([story]),
         addNewAttributes: sinon.stub().returns(story)
       };
-      const fakeGetState = sinon.stub();
-      fakeGetState.returns({
-        stories: { all: [updatedStory] },
+      const fakeGetState = sinon.stub().returns({
+        stories: { all: updatedStories },
       });
 
       const fakeDispatch = sinon.stub().resolves({});
 
       await Story.dragDropStory(story.id, story.projectId, {
         position: 3.54,
+        newPosition: 4,
       }, from)(fakeDispatch, fakeGetState, { Story: FakeStory });
 
-      expect(fakeDispatch).toHaveBeenCalledWith(Story.updateStorySuccess(updatedStory, from));
+      expect(fakeDispatch).toHaveBeenCalledWith(Story.sortStoriesSuccess(updatedStories, from));
 
     });
 
@@ -296,14 +297,14 @@ describe('Story Actions', () => {
 
       const FakeStory = {
         findById: sinon.stub().returns(updatedStory),
-        update: sinon.stub().rejects(error),
+        sort: sinon.stub().rejects(error),
         isNew: sinon.stub().returns(false),
         withScope: sinon.stub().returns([story]),
         addNewAttributes: sinon.stub().returns(story)
       };
 
       const fakeGetState = sinon.stub().returns({
-        stories: { all: [updatedStory] },
+        stories: { all: updatedStories },
       });
 
       const fakeDispatch = sinon.stub().resolves({});
@@ -320,9 +321,9 @@ describe('Story Actions', () => {
         );
       });
 
-      it('do not dispatch updateStorySuccess', () => {
+      it('do not dispatch sortStoriesSuccess', () => {
         expect(fakeDispatch).not.toHaveBeenCalledWith(
-          Story.updateStorySuccess(updatedStory),
+          Story.sortStoriesSuccess(updatedStory),
         );
       });
     });
@@ -537,13 +538,13 @@ describe('Story Actions', () => {
 
       it('dispatch receiveStories with stories in epic scope', async () => {
         await Story.fetchEpic(label)(fakeDispatch, fakeGetState, { Story: fakeStory });
-    
+
         expect(fakeDispatch).toHaveBeenCalledWith(Story.receiveStories(stories, 'epic'));
       });
 
       it('does not dispatch sendDefaultErrorNotification', async () => {
         await Story.fetchEpic(label)(fakeDispatch, fakeGetState, { Story: fakeStory });
-    
+
         expect(fakeDispatch).not.toHaveBeenCalledWith(sendDefaultErrorNotification());
       });
     });

--- a/spec/javascripts/models/beta/project_board_spec.js
+++ b/spec/javascripts/models/beta/project_board_spec.js
@@ -166,8 +166,8 @@ describe('ProjectBoard model', () => {
 
 
   describe('Drag and Drop', () => {
-    describe('getNewPosition', () => {
-      const array = [{ position: 24, state: 'finished' }, { position: 20, state: 'finished' }, { position: 16, state: 'unstarted' }, { position: 12, state: 'unstarted' }, { position: 8, state: 'started' }, { position: 4, state: 'started' }];
+    describe('getPositions', () => {
+      const array = [{ newPosition: 24, position: 24, state: 'finished' }, { newPosition: 20, position: 20, state: 'finished' }, { newPosition: 16, position: 16, state: 'unstarted' }, { newPosition: 12, position: 12, state: 'unstarted' }, { newPosition: 8, position: 8, state: 'started' }, { newPosition: 4, position: 4, state: 'started' }];
 
       describe('same column', () => {
         const isSameColumn = true;
@@ -176,14 +176,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 2;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'unstarted',
               ),
-            ).toEqual(15);
+            ).toEqual([15,15]);
           });
         });
 
@@ -192,14 +192,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 1;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'finished',
               ),
-            ).toEqual(21);
+            ).toEqual([21,21]);
           });
         });
 
@@ -208,14 +208,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 0;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'finished',
               ),
-            ).toEqual(23);
+            ).toEqual([23,1]);
           });
         });
 
@@ -224,14 +224,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 5;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'started',
               ),
-            ).toEqual(5);
+            ).toEqual([5,5]);
           });
         });
       });
@@ -243,14 +243,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 2;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'unstarted',
               ),
-            ).toEqual(15);
+            ).toEqual([15,15]);
           });
         });
 
@@ -259,14 +259,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 0;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'finished',
               ),
-            ).toEqual(23);
+            ).toEqual([23,1]);
           });
         });
 
@@ -275,14 +275,14 @@ describe('ProjectBoard model', () => {
           const destinationIndex = 6;
           it('returns a new position', () => {
             expect(
-              ProjectBoard.getNewPosition(
+              ProjectBoard.getPositions(
                 destinationIndex,
                 sourceIndex,
                 array,
                 isSameColumn,
                 'started',
               ),
-            ).toEqual(5);
+            ).toEqual([5,5]);
           });
         });
       });

--- a/spec/javascripts/models/beta/story_spec.js
+++ b/spec/javascripts/models/beta/story_spec.js
@@ -7,11 +7,11 @@ describe('Story model', function () {
     describe('when position A is bigger then B', () => {
       it("return 1", () => {
         const storyA = {
-          position: "10.7"
+          newPosition: 10
         };
 
         const storyB = {
-          position: "4.3"
+          newPosition: 4
         }
 
         expect(Story.comparePosition(storyA, storyB)).toEqual(1)
@@ -21,11 +21,11 @@ describe('Story model', function () {
     describe('when position A is lower then B', () => {
       it("return -1", () => {
         const storyA = {
-          position: "3.4"
+          newPosition: 3
         };
 
         const storyB = {
-          position: "5.3"
+          newPosition: 5
         }
 
         expect(Story.comparePosition(storyA, storyB)).toEqual(-1)
@@ -35,11 +35,11 @@ describe('Story model', function () {
     describe('when position A is equal B', () => {
       it("return 0", () => {
         const storyA = {
-          position: "5.0"
+          newPosition: 5
         };
 
         const storyB = {
-          position: "5.0"
+          newPosition: 5
         }
 
         expect(Story.comparePosition(storyA, storyB)).toEqual(0)
@@ -257,7 +257,7 @@ describe('Story model', function () {
           const story = { _editing: { storyType: FEATURE, estimate: 1 } };
           const newAttributes = { storyType: noFeatureType }
           let changedStory;
-          
+
           beforeEach(() => {
             changedStory = Story.editStory(story, newAttributes);
           })
@@ -265,7 +265,7 @@ describe('Story model', function () {
           it('change story estimate to ""', () => {
             expect(changedStory._editing.estimate).toEqual('');
           })
-        
+
           it(`change story type is ${noFeatureType}`, () => {
             expect(changedStory._editing.storyType).toEqual(noFeatureType);
           })
@@ -281,8 +281,8 @@ describe('Story model', function () {
           beforeEach(() => {
             changedStory = Story.editStory(story, newAttributes);
           });
-          
-          it("keep estimate 1", () => {    
+
+          it("keep estimate 1", () => {
             expect(changedStory._editing.estimate).toEqual(1);
           });
 
@@ -303,7 +303,7 @@ describe('Story model', function () {
               changedStory = Story.editStory(story, newAttributes);
             });
 
-            it(`change state to unscheduled `, () => {    
+            it(`change state to unscheduled `, () => {
               expect(changedStory._editing.state).toEqual(UNSCHEDULED);
             });
 
@@ -320,7 +320,7 @@ describe('Story model', function () {
             const story = { _editing: { storyType: FEATURE, estimate: '', state: UNSCHEDULED } };
             const newAttributes = { estimate: estimatedValue };
             let changedStory;
-            
+
             beforeEach(() => {
               changedStory = Story.editStory(story, newAttributes);
             });
@@ -341,12 +341,12 @@ describe('Story model', function () {
       describe(`when story type is ${noFeatureType}`, () => {
         const otherNotFeatureTypes = notFeatureTypes.filter(type => type !== noFeatureType);
 
-        otherNotFeatureTypes.forEach(otherNotFeatureType => {          
+        otherNotFeatureTypes.forEach(otherNotFeatureType => {
           describe(`and new story type is ${otherNotFeatureType}`, () => {
             const story = { _editing: { storyType: noFeatureType, estimate: '' } };
             const newAttributes = { storyType: otherNotFeatureType }
             let changedStory;
-          
+
             beforeEach(() => {
               changedStory = Story.editStory(story, newAttributes);
             });
@@ -379,10 +379,10 @@ describe('Story model', function () {
 
         describe(`and story status is ${UNSCHEDULED}`, () => {
           describe(`and new story type is feature`, () => {
-            const story = { _editing: { 
-              storyType: noFeatureType, 
-              estimate: '', 
-              state: UNSCHEDULED } 
+            const story = { _editing: {
+              storyType: noFeatureType,
+              estimate: '',
+              state: UNSCHEDULED }
             };
             const newAttributes = { storyType: FEATURE }
             let changedStory;
@@ -391,7 +391,7 @@ describe('Story model', function () {
               changedStory = Story.editStory(story, newAttributes);
             });
 
-            it('change estimate to ""', () => {    
+            it('change estimate to ""', () => {
               expect(changedStory._editing.estimate).toEqual('');
             });
 
@@ -407,11 +407,11 @@ describe('Story model', function () {
 
         describe(`when story status is ${UNSTARTED}`, () => {
           describe(`when new story type is feature`, () => {
-            const story = { _editing: { 
+            const story = { _editing: {
                 storyType: noFeatureType,
                 estimate: 2,
                 state: UNSTARTED
-              } 
+              }
             };
             const newAttributes = { storyType: FEATURE }
             let changedStory;
@@ -444,7 +444,7 @@ describe('Story model', function () {
               changedStory = Story.editStory(story, newAttributes);
             });
 
-            it("change estimate to ''", () => {            
+            it("change estimate to ''", () => {
               expect(changedStory._editing.estimate).toEqual('');
             });
 
@@ -1140,7 +1140,7 @@ describe('Story model', function () {
     describe('when highlighted is false', () => {
       it('returns falsy', () => {
         const story = { highlighted: false };
-        
+
         expect(Story.isHighlighted(story)).toBeFalsy();
       });
     });
@@ -1159,7 +1159,7 @@ describe('Story model', function () {
 
         expect(Story.isHighlighted(story)).toBeFalsy();
       });
-    }); 
+    });
   });
 
   describe('isSearch', () => {
@@ -1228,8 +1228,8 @@ describe('Story model', function () {
 
   describe('haveSearch', () => {
     describe('when have zero search stories', () => {
-      const stories = { 
-        [storyScopes.SEARCH]: [] 
+      const stories = {
+        [storyScopes.SEARCH]: []
       };
 
       it('returns falsy', () => {
@@ -1341,7 +1341,7 @@ describe('Story model', function () {
           const story = { _editing: { id: 1, storyType: noFeatureType, estimate: '' } };
           const newAttributes = { estimate: 2 };
           const newStory = { ...story, ...newAttributes };
-  
+
           it('return an empty string', () => {
             expect(Story.estimateFor(story, newAttributes, newStory)).toEqual('');
           });

--- a/spec/javascripts/selectors/backlog_spec.js
+++ b/spec/javascripts/selectors/backlog_spec.js
@@ -75,7 +75,7 @@ describe('Backlog selector functions', () => {
 
         const stories = [newStory, oldStory];
         const orderedStories = orderByState(stories);
-        
+
         expect(orderedStories[0]).toEqual(oldStory);
         expect(orderedStories[1]).toEqual(newStory);
       });
@@ -97,7 +97,7 @@ describe('Backlog selector functions', () => {
 
         const stories = [newStory, oldStory];
         const orderedStories = orderByState(stories);
-        
+
         expect(orderedStories[0]).toEqual(oldStory);
         expect(orderedStories[1]).toEqual(newStory);
       });
@@ -119,7 +119,7 @@ describe('Backlog selector functions', () => {
 
         const stories = [newStory, oldStory];
         const orderedStories = orderByState(stories);
-        
+
         expect(orderedStories[0]).toEqual(oldStory);
         expect(orderedStories[1]).toEqual(newStory);
       });
@@ -127,24 +127,24 @@ describe('Backlog selector functions', () => {
 
     describe('All stories are rejected, finished or unstarted', () => {
       const storyStates = ['rejected', 'finished', 'unstarted'];
-      
+
       it('sort by position', () => {
         storyStates.forEach(state => {
           const firstPosition = storyFactory({
             id: 1,
-            position: '1',
+            newPosition: 1,
             state,
           });
 
           const secondPosition = storyFactory({
             id: 0,
-            position: '2',
+            newPosition: 2,
             state,
           });
-  
+
           const stories = [secondPosition, firstPosition];
           const orderedStories = orderByState(stories);
-          
+
           expect(orderedStories[0]).toEqual(firstPosition);
           expect(orderedStories[1]).toEqual(secondPosition);
         });

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -469,7 +469,7 @@ describe Story do
           title accepted_at created_at release_date updated_at delivered_at description
           project_id story_type owned_by_id requested_by_id
           requested_by_name owned_by_name owned_by_initials estimate
-          state position id errors labels notes tasks documents
+          state position id errors labels notes tasks documents new_position
         ].sort
       )
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ RSpec.configure do |config|
   config.default_retry_count = 2
   config.exceptions_to_retry = [Net::ReadTimeout]
 
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include IntegrationHelpers,            type: :feature
+  config.include Devise::Test::ControllerHelpers,  type: :controller
+  config.include IntegrationHelpers,               type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/beta/stories_controller_spec.rb
+++ b/spec/requests/beta/stories_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Ordering stories', type: :request do
+  let(:user) { create :user, :with_team }
+  let(:project) do
+    create(:project, name: 'Test Project', users: [user], teams: [user.teams.first])
+  end
+
+  context 'when moving story in the same state' do
+    let!(:bug) { create(:story, :active, project: project, requested_by: user, new_position: 1) }
+    let!(:chore) { create(:story, :active, project: project, requested_by: user, new_position: 2) }
+    let!(:feature) { create(:story, :active, project: project, requested_by: user, new_position: 3) }
+
+    before do
+      sign_in user
+      PunditContext.new(user.teams.first, user, current_project: project)
+      post sort_beta_stories_path, params: { story: { position: 4, new_position: 4, id: chore.id, state: 'started', project_id: project.id } }
+    end
+
+    it 'moves story to correct position' do
+      chore_new_position = chore.reload.new_position
+      bug_new_position = bug.reload.new_position
+      feature_new_position = feature.reload.new_position
+      expect(chore_new_position).to eq(4)
+      expect(bug_new_position).to eq(1)
+      expect(feature_new_position).to eq(3)
+    end
+  end
+
+  context 'when moving story in different state' do
+    let!(:bug) { create(:story, state: 'unscheduled', project: project, requested_by: user, new_position: 1) }
+    let!(:chore) { create(:story, :active, project: project, requested_by: user, new_position: 1) }
+    let!(:feature) { create(:story, :active, project: project, requested_by: user, new_position: 2) }
+
+    before do
+      sign_in user
+      PunditContext.new(user.teams.first, user, current_project: project)
+      post sort_beta_stories_path, params: { story: { position: 0, new_position: 1, id: bug.id, state: 'started', project_id: project.id } }
+    end
+
+    it 'moves story to correct position' do
+      chore_new_position = chore.reload.new_position
+      bug_new_position = bug.reload.new_position
+      feature_new_position = feature.reload.new_position
+      expect(chore_new_position).to eq(2)
+      expect(bug_new_position).to eq(1)
+      expect(feature_new_position).to eq(3)
+    end
+  end
+end

--- a/spec/requests/beta/stories_controller_spec.rb
+++ b/spec/requests/beta/stories_controller_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Ordering stories', type: :request do
 
     before do
       sign_in user
-      PunditContext.new(user.teams.first, user, current_project: project)
       post sort_beta_stories_path, params: { story: { position: 4, new_position: 4, id: chore.id, state: 'started', project_id: project.id } }
     end
 

--- a/spec/requests/beta/stories_controller_spec.rb
+++ b/spec/requests/beta/stories_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Ordering stories', type: :request do
 
     before do
       sign_in user
-      post sort_beta_stories_path, params: { story: { position: 4, new_position: 4, id: chore.id, state: 'started', project_id: project.id } }
+      post position_beta_story_path(id: chore.id), params: { story: { position: 4, new_position: 4, id: chore.id, state: 'started', project_id: project.id }, id: chore.id }
     end
 
     it 'moves story to correct position' do
@@ -33,8 +33,7 @@ RSpec.describe 'Ordering stories', type: :request do
 
     before do
       sign_in user
-      PunditContext.new(user.teams.first, user, current_project: project)
-      post sort_beta_stories_path, params: { story: { position: 0, new_position: 1, id: bug.id, state: 'started', project_id: project.id } }
+      post position_beta_story_path(id: bug.id), params: { story: { position: 0, new_position: 1, id: bug.id, state: 'started', project_id: project.id } }
     end
 
     it 'moves story to correct position' do


### PR DESCRIPTION
**DESCRIPTION**

A new sorting logic has been implemented, due to the problems caused by the float limitations in relation to the number of decimal places, which affected the scalability of the old method. Then an algorithm was implemented that will add 1 to the modified story and to all in front of it.

**CHANGELOG**

- Created a column called "new_position" to all stories
- A script to populate it - `bundle rake populate_newposition` to run
- Created a new route to update stories with this method - `/beta/sort`
- Created specs in backend
- Change sort logic in frontend
- Update specs in frontend