### PR TITLE
Add 'Accepted by' to Expanded history

### DIFF
--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAcceptedBy.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryAcceptedBy.js
@@ -1,0 +1,42 @@
+import React, {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
+import { editingStoryPropTypesShape } from '../../../models/beta/story';
+import ExpandedStorySection from './ExpandedStorySection';
+
+import { getHistory } from '../../../models/beta/story';
+import { findById } from '../../../models/beta/user';
+
+const ExpandedStoryAcceptedBy = ({ users, story }) => {
+  const [userInfo, setUserInfo] = useState({})
+
+  useEffect(() => {
+    async function fetchData() {
+      const history = await getHistory(story.id, story.projectId, users);
+      const userId = history[0].activity["user_id"]
+      const user = await findById(users, userId);
+      setUserInfo(user)
+    }
+
+    fetchData()
+  }, [story]);
+
+  return (
+      <ExpandedStorySection
+      title={I18n.t('activerecord.attributes.story.accepted_by')}
+    >
+      <input
+        value={userInfo.name || "----" }
+        className="form-control input-sm"
+        readOnly={true}
+      />
+    </ExpandedStorySection>
+  );
+
+}
+
+ExpandedStoryAcceptedBy.propTypes = {
+  users: PropTypes.array.isRequired,
+  story: editingStoryPropTypesShape.isRequired
+}
+
+export default ExpandedStoryAcceptedBy;

--- a/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDefault/index.js
+++ b/app/assets/javascripts/components/story/ExpandedStory/ExpandedStoryDefault/index.js
@@ -20,6 +20,7 @@ import ExpandedStoryAttachments from '../ExpandedStoryAttachments';
 import ExpandedStoryTask from '../ExpandedStoryTask';
 import ExpandedStoryRequestedBy from '../ExpandedStoryRequestedBy';
 import ExpandedStoryOwnedBy from '../ExpandedStoryOwnedBy';
+import ExpandedStoryAcceptedBy from '../ExpandedStoryAcceptedBy';
 
 export const ExpandedStoryDefault = ({
   titleRef,
@@ -83,6 +84,14 @@ export const ExpandedStoryDefault = ({
       onEdit={(ownedById) => onEdit({ ownedById })}
       disabled={disabled}
     />
+
+    {
+      story.acceptedAt !== null &&
+        <ExpandedStoryAcceptedBy
+          story={story}
+          users={users}
+        />
+    }
 
     <ExpandedStoryLabels
       onAddLabel={(label) => addLabel(story.id, label)}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
         state:                'State'
         started_at:           'Started at'
         accepted_at:          'Accepted at'
+        accepted_by:          'Accepted by'
         updated_at:           'Updated at'
         position:             'Position'
         labels:               'Labels'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -204,6 +204,7 @@ es:
         state:                'Estado'
         started_at:           'Empezó a las'
         accepted_at:          'Aceptada en'
+        accepted_by:          'Aceptada por'
         updated_at:           'Actualizado en'
         position:             'Posición'
         labels:               'Etiquetas'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -212,6 +212,7 @@ pt-BR:
         state:                'Estado'
         started_at:           'Iniciada em'
         accepted_at:          'Aceita em'
+        accepted_by:          'Aceita por'
         updated_at:           'Atualizado em'
         position:             'Posição'
         labels:               'Etiquetas'


### PR DESCRIPTION
I created a new file "ExpandedStoryAcceptedBy.js" and updates on "config/locales" to add the "accepted_by" translation and "ExpandedStoryDefault" to display the "accepted_by" information only if the story was already accepted