### PR TITLE
Fix babel warnings about deprecated options

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,9 +6,10 @@
       {
         "modules": false,
         "targets": {
-          "browsers": "> 1%",
-          "uglify": true
+          "browsers": "> 1%"
         },
+        "corejs": "2.0",
+        "forceAllTransforms": true,
         "useBuiltIns": "usage"
       }
     ]


### PR DESCRIPTION
After running jest, babel showed warning about the option uglify that became deprecated and changed to forceAllTransforms, and corejs that wasn't defined, so babel assumed that was version 2, but there are already version 3, so will be more obvious and protect the code if we define it's version, and the version described on package.json was version 2.

Babel warnings that was fixed:
![image](https://user-images.githubusercontent.com/30053543/162816707-9b0fb656-b564-48b9-9833-6fe1edbd4d0f.png)

Link for the doc
core-js: https://babeljs.io/docs/en/babel-preset-env#corejs
forceAllTransforms: https://babeljs.io/docs/en/babel-preset-env#forcealltransforms