### PR TITLE
fix: remove user membership when he owns an accepted story

### DIFF
--- a/app/services/remove_stories_from_user_service.rb
+++ b/app/services/remove_stories_from_user_service.rb
@@ -9,8 +9,10 @@ class RemoveStoriesFromUserService
   end
 
   def call
-    project.stories.where(requested_by_id: user.id)
-           .or(project.stories.where(owned_by_id: user.id)).each do |story|
+    project.stories
+           .where(requested_by_id: user.id)
+           .or(project.stories.where(owned_by_id: user.id))
+           .where.not(state: "accepted").each do |story|
 
       requested_by_attrs = user.requested?(story) ? { requested_by_id: nil, requested_by_name: nil } : {}
       owned_by_attrs = user.owns?(story) ? { owned_by_id: nil, owned_by_name: nil } : {}

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -121,6 +121,16 @@ describe UsersController do
             delete :destroy, params: { project_id: project.id, id: another_user.id }
             expect(response).to redirect_to(root_url)
           end
+
+          context 'user has accepted stories attached' do
+            let!(:story) { create(:story, :done, project: project, owned_by: another_user, requested_by: user) }
+
+            it 'deletes user membership' do
+              expect {
+                delete :destroy, params: { project_id: project.id, id: another_user.id }
+              }.to change{ project.users.reload.include? another_user }.from(true).to(false)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Admins weren't able to remove users from projects when said user owned an accepted story. The PR fixes this issue by addressing this condition on the service that handles the user removal. 