### PR TITLE
Fix missing docker chromedriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,16 @@ RUN gem install bundler
 RUN curl -sSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" | tar xfJ - -C /usr/local --strip-components=1
 RUN npm install --global --unsafe-perm yarn
 
+ENV CHROME_VERSION 106.0.5249.61
+RUN wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb \
+  && dpkg -i google-chrome-stable_${CHROME_VERSION}-1_amd64.deb || true \
+  && apt-get -f install -y \
+  && rm -v google-chrome-stable_${CHROME_VERSION}-1_amd64.deb \
+  && wget https://chromedriver.storage.googleapis.com/${CHROME_VERSION}/chromedriver_linux64.zip \
+  && unzip chromedriver_linux64.zip -d /usr/local/bin \
+  && rm chromedriver_linux64.zip
+
+
 WORKDIR /tmp
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock


### PR DESCRIPTION
Add chromedriver installation to Dockerfile to be able to run tests inside docker containers.