### PR TITLE
Refactor/StoryOperations::Create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,16 @@ RUN gem install bundler
 RUN curl -sSL "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" | tar xfJ - -C /usr/local --strip-components=1
 RUN npm install --global --unsafe-perm yarn
 
+ENV CHROME_VERSION 106.0.5249.61
+RUN wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb \
+  && dpkg -i google-chrome-stable_${CHROME_VERSION}-1_amd64.deb || true \
+  && apt-get -f install -y \
+  && rm -v google-chrome-stable_${CHROME_VERSION}-1_amd64.deb \
+  && wget https://chromedriver.storage.googleapis.com/${CHROME_VERSION}/chromedriver_linux64.zip \
+  && unzip chromedriver_linux64.zip -d /usr/local/bin \
+  && rm chromedriver_linux64.zip
+
+
 WORKDIR /tmp
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'user_impersonate2', require: 'user_impersonate'
 gem 'virtus'
 gem 'webpacker', '~> 5.4.3'
 gem 'pusher'
+gem 'dry-monads'
+gem 'dry-matcher'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-jquery.gritter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,11 @@ GEM
     dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
+    dry-matcher (0.9.0)
+      dry-core (~> 0.4, >= 0.4.8)
+    dry-monads (1.4.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.7)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
@@ -643,6 +648,8 @@ DEPENDENCIES
   devise-i18n
   differ
   dotenv-rails
+  dry-matcher
+  dry-monads
   enumerize (~> 2.5.0)
   factory_bot_rails
   faraday

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,3 +1,5 @@
+require "dry/matcher/result_matcher"
+
 class StoriesController < ApplicationController
   include ActionView::Helpers::TextHelper
 
@@ -75,13 +77,19 @@ class StoriesController < ApplicationController
     @story = policy_scope(Story).build(allowed_params)
     authorize @story
     @story.requested_by_id = current_user.id unless @story.requested_by_id
-    respond_to do |format|
-      if StoryOperations::Create.call(@story, current_user)
-        format.html { redirect_to project_url(@project) }
-        format.js   { render json: @story }
-      else
-        format.html { render action: 'new' }
-        format.js   { render json: @story, status: :unprocessable_entity }
+    story = BetaStoryOperations::Create.new.call(story: @story, current_user: current_user)
+    Dry::Matcher::ResultMatcher.(story) do |on|
+      on.success do |story|
+        respond_to do |format|
+          format.html { redirect_to project_url(@project) }
+          format.js   { render json: story }
+        end
+      end
+      on.failure do |story|
+        respond_to do |format|
+          format.html { render action: 'new' }
+          format.js   { render json: story, status: :unprocessable_entity }
+        end
       end
     end
   end

--- a/app/operations/base/activity_recording.rb
+++ b/app/operations/base/activity_recording.rb
@@ -1,0 +1,25 @@
+module Base
+  class ActivityRecording
+    def self.create_activity(model, current_user)
+      Activity.create(
+        project: fetch_project(model),
+        user: current_user,
+        action: self.class.name.split('::').last.downcase,
+        subject: model
+      )
+    end
+
+    private
+
+    def self.fetch_project(model)
+      case model
+      when Project
+        model
+      when Story
+        model.project
+      when Note, Task
+        model.story.project
+      end
+    end
+  end
+end

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -1,4 +1,4 @@
-require 'story_operations/member_notification'
+require 'story_operations/legacy_member_notification'
 require 'story_operations/state_change_notification'
 require 'story_operations/legacy_fixes'
 require 'story_operations/pusher_notification'
@@ -19,7 +19,7 @@ module StoryOperations
   end
 
   class Update < BaseOperations::Update
-    include MemberNotification
+    include LegacyMemberNotification
     include StateChangeNotification
     include LegacyFixes
     include PusherNotification

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -1,7 +1,7 @@
 require 'story_operations/legacy_member_notification'
 require 'story_operations/state_change_notification'
 require 'story_operations/legacy_fixes'
-require 'story_operations/pusher_notification'
+require 'story_operations/legacy_pusher_notification'
 require 'story_operations/state_ensurement'
 
 module StoryOperations
@@ -22,7 +22,7 @@ module StoryOperations
     include LegacyMemberNotification
     include StateChangeNotification
     include LegacyFixes
-    include PusherNotification
+    include LegacyPusherNotification
     include StateEnsurement
 
     def before_save
@@ -59,7 +59,7 @@ module StoryOperations
   class UpdateAll < BaseOperations::UpdateAll; end
 
   class Destroy < BaseOperations::Destroy
-    include PusherNotification
+    include LegacyPusherNotification
 
     def after_save
       notify_changes

--- a/app/operations/story_operations/legacy_member_notification.rb
+++ b/app/operations/story_operations/legacy_member_notification.rb
@@ -1,5 +1,5 @@
 module StoryOperations
-  module MemberNotification
+  module LegacyMemberNotification
     def self.included(base)
       base.class_eval do
         attr_reader :users_to_notify

--- a/app/operations/story_operations/legacy_pusher_notification.rb
+++ b/app/operations/story_operations/legacy_pusher_notification.rb
@@ -1,0 +1,13 @@
+module StoryOperations
+  module LegacyPusherNotification
+    def notify_changes
+      ::PusherNotificationWorker.perform_async(channel_name)
+    end
+
+    private
+
+    def channel_name
+      "project-board-#{model.project_id}"
+    end
+  end
+end

--- a/app/operations/story_operations/pusher_notification.rb
+++ b/app/operations/story_operations/pusher_notification.rb
@@ -1,13 +1,24 @@
 module StoryOperations
-  module PusherNotification
+  class PusherNotification
+
+    def self.notify_changes(story)
+      new(story).notify_changes
+    end
+
+    def initialize(story)
+      @story = story
+    end
+
     def notify_changes
       ::PusherNotificationWorker.perform_async(channel_name)
     end
 
     private
 
+    attr_reader :story
+
     def channel_name
-      "project-board-#{model.project_id}"
+      "project-board-#{story.project_id}"
     end
   end
 end

--- a/app/operations/story_operations/user_notification.rb
+++ b/app/operations/story_operations/user_notification.rb
@@ -1,0 +1,32 @@
+module StoryOperations 
+  class UserNotification
+    def self.notify_users(story)
+      new(story).notify_users
+    end
+
+    def initialize(story)
+      @story = story
+    end
+
+    def notify_users
+      return if !notify_mentioned_users?
+      Notifications.story_mention(story, users_to_notify.pluck(:email)).deliver_later
+    end
+
+    private
+
+    attr_reader :story
+
+    def users_to_notify
+      usernames = UsernameParser.parse(story.description)
+      
+      return [] if usernames.empty?
+
+      story.users.where(username: usernames).all
+    end
+
+    def notify_mentioned_users?
+      story.description.present? && users_to_notify.any? && !story.suppress_notifications
+    end
+  end
+end

--- a/spec/operations/story_operations/legacy_pusher_notification_spec.rb
+++ b/spec/operations/story_operations/legacy_pusher_notification_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe StoryOperations::PusherNotification do
+describe StoryOperations::LegacyPusherNotification do
   class PusherClass
-    include StoryOperations::PusherNotification
+    include StoryOperations::LegacyPusherNotification
     attr_reader :user, :model
 
     def initialize(model, user)

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -54,7 +54,7 @@ describe StoryOperations do
       it { expect(Notifications).to_not receive(:story_mention) }
     end
 
-    context '::MemberNotification' do
+    context '::UserNotification' do
       let(:mailer) { double('mailer') }
       let(:username_user) do
         project.users.create(

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -12,12 +12,12 @@ describe StoryOperations do
   let(:story)       { project.stories.build(story_params) }
 
   describe '::Create' do
-    subject { -> { StoryOperations::Create.call(story, user) } }
+    subject { -> { StoryOperations::Create.new.call(story: story, current_user: user) } }
 
     context 'with valid params' do
       it { expect { subject.call }.to change { Story.count } }
       it { expect { subject.call }.to change { Changeset.count } }
-      it { expect(subject.call).to be_eql Story.last }
+      it { expect(subject.call.value!).to be_eql Story.last }
 
       Story::ESTIMABLE_TYPES.each do |story_type|
         context "a #{story_type} story" do
@@ -50,7 +50,7 @@ describe StoryOperations do
       before { story.title = '' }
 
       it { is_expected.to_not change { Story.count } }
-      it { expect(subject.call).to be_falsy }
+      it { expect(subject.call.success?).to be_falsy }
       it { expect(Notifications).to_not receive(:story_mention) }
     end
 


### PR DESCRIPTION
Refactor StoryOperations::Create to use [dry-monads](https://github.com/dry-rb/dry-monads) and [dry-matcher](https://github.com/dry-rb/dry-matcher), making use of variables and calls clearer.

Co-authored-by: Carlos Henrique <https://github.com/carlospazuzu>