### PR TITLE
Refactor/StoryOperations::Destroy

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -61,7 +61,7 @@ class StoriesController < ApplicationController
   def destroy
     @story = policy_scope(Story).find(params[:id])
     authorize @story
-    StoryOperations::Destroy.call(@story, current_user)
+    StoryOperations::Destroy.new.call(story: @story, current_user: current_user)
     head :ok
   end
 

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -442,7 +442,7 @@ describe StoryOperations do
       it 'notifies the pusher that the board has changes' do
         expect(PusherNotificationWorker).to receive(:perform_async)
 
-        StoryOperations::Destroy.call(story, user)
+        StoryOperations::Destroy.new.call(story: story, current_user: user)
       end
     end
   end


### PR DESCRIPTION
Refactor StoryOperations::Destroy to use [dry-monads](https://github.com/dry-rb/dry-monads) and [dry-matcher](https://github.com/dry-rb/dry-matcher), making use of variables and calls clearer.