### PR TITLE
Refactor/StoryOperations::UpdateAll

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
+require "dry/monads/result"
+require "dry/matcher/result_matcher"
+
 class ApplicationController < ActionController::Base
   protect_from_forgery prepend: true
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
-require "dry/monads/result"
-require "dry/matcher/result_matcher"
+require 'dry/monads/result'
+require 'dry/matcher/result_matcher'
 
 class ApplicationController < ActionController::Base
   protect_from_forgery prepend: true

--- a/app/controllers/stories_bulk_update_controller.rb
+++ b/app/controllers/stories_bulk_update_controller.rb
@@ -3,9 +3,21 @@ class StoriesBulkUpdateController < ApplicationController
     authorize stories
 
     return render(json: { message: 'Stories not found' }, status: :not_found) if stories.blank?
-    @updater = StoryOperations::UpdateAll.call(stories, allowed_params, current_user)
 
-    returns_message @updater
+    result = StoryOperations::UpdateAll.new.call(
+      stories: stories,
+      data: allowed_params,
+      current_user: current_user
+    )
+
+    match_result(result) do |on|
+      on.success do |stories|
+        returns_message stories
+      end
+      on.failure do
+        returns_message false
+      end
+    end
   end
 
   private

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -159,6 +159,7 @@ module StoryOperations
 
     private
 
+    # TODO: we should probably use a transaction here
     def update_stories(stories:, data:, current_user:)
       updated_stories = stories.map do |story|
         Update.new.call(story: story, data: data, current_user: current_user)

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -142,7 +142,33 @@ module StoryOperations
     end
   end
 
-  class UpdateAll < BaseOperations::UpdateAll; end
+  class UpdateAll
+    include Dry::Monads[:result, :do]
+
+    def call(stories:, data:, current_user:)
+      stories = yield update_stories(
+        stories: stories,
+        data: data,
+        current_user: current_user
+      )
+
+      Success(stories)
+    rescue
+      Failure(false)
+    end
+
+    private
+
+    def update_stories(stories:, data:, current_user:)
+      updated_stories = stories.map do |story|
+        Update.new.call(story: story, data: data, current_user: current_user)
+      end
+
+      return Failure(updated_stories) if updated_stories.map(&:success?).include?(false)
+
+      Success(updated_stories)
+    end
+  end
 
   class Destroy
     include Dry::Monads[:result, :do]

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -164,7 +164,7 @@ module StoryOperations
         Update.new.call(story: story, data: data, current_user: current_user)
       end
 
-      return Failure(updated_stories) if updated_stories.map(&:success?).include?(false)
+      return Failure(updated_stories) unless updated_stories.all?(&:success?)
 
       Success(updated_stories)
     end

--- a/spec/controllers/stories_bulk_update_controller_spec.rb
+++ b/spec/controllers/stories_bulk_update_controller_spec.rb
@@ -59,7 +59,7 @@ describe StoriesBulkUpdateController do
 
       context 'when set invalid owner' do
         before do
-          post :create, params: params.merge(owned_by_id: user_4)
+          post :create, params: params.merge(owned_by_id: user_4.id)
         end
 
         it 'responds with 422' do

--- a/spec/controllers/stories_bulk_update_controller_spec.rb
+++ b/spec/controllers/stories_bulk_update_controller_spec.rb
@@ -59,7 +59,7 @@ describe StoriesBulkUpdateController do
 
       context 'when set invalid owner' do
         before do
-          post :create, params: params.merge(owned_by_id: user_4.id)
+          post :create, params: params.merge(owned_by_id: user_4)
         end
 
         it 'responds with 422' do

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -544,17 +544,17 @@ describe StoryOperations do
     let(:story_2)   { create(:story, project: project_1, requested_by: user_2) }
     let(:story_3)   { create(:story, project: project_2, requested_by: user_3) }
 
-    subject { StoryOperations::UpdateAll }
+    subject { StoryOperations::UpdateAll.new }
 
     let(:result) do
       stories = [story_1, story_2, story_3]
       params = { labels: 'backend', requested_by_id: user_2.id, owned_by_id: user_1.id }
-      subject.call(stories, params, user_1)
+      subject.call(stories: stories, data: params, current_user: user_1)
     end
 
     context 'when the user is not of the same project' do
       it 'does not update any story' do
-        expect(result).to eq(false)
+        expect(result.success?).to be_falsy
       end
     end
   end


### PR DESCRIPTION
Refactor StoryOperations::UpdateAll to use [dry-monads](https://github.com/dry-rb/dry-monads) and [dry-matcher](https://github.com/dry-rb/dry-matcher), making use of variables and calls clearer.