### PR TITLE
Refactor/StoryOperation::DestroyAll

### DIFF
--- a/app/controllers/stories_bulk_destroy_controller.rb
+++ b/app/controllers/stories_bulk_destroy_controller.rb
@@ -1,15 +1,22 @@
 class StoriesBulkDestroyController < ApplicationController
   def create
     authorize stories
-    destroyed_stories = StoryOperations::DestroyAll.call(stories, current_user)
 
-    if destroyed_stories
-      render json: { message: t(:stories_destroy_success) }, status: :ok
-    else
-      render(
-        json: { errors: t(:stories_destroy_fail) },
-        status: :unprocessable_entity
-      )
+    result = StoryOperations::DestroyAll.new.call(
+      stories: stories,
+      current_user: current_user
+    )
+
+    match_result(result) do |on|
+      on.success do |stories|
+        render json: { message: t(:stories_destroy_success) }, status: :ok
+      end
+      on.failure do
+        render(
+          json: { errors: t(:stories_destroy_fail) },
+          status: :unprocessable_entity
+        )
+      end
     end
   end
 

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -199,7 +199,27 @@ module StoryOperations
     end
   end
 
-  class DestroyAll < BaseOperations::DestroyAll; end
+  class DestroyAll
+    include Dry::Monads[:result, :do]
+
+    def call(stories:, current_user:)
+      stories = yield destroy_stories(
+        stories: stories,
+        current_user: current_user
+      )
+
+      Success(stories)
+    rescue
+      Failure(false)
+    end
+
+    private
+
+    def destroy_stories(stories:, current_user:)
+      deleted_stories = stories.destroy_all
+      Success(deleted_stories)
+    end
+  end
 
   class ReadAll
     delegate :past_iterations, :current_iteration_start, to: :iterations

--- a/spec/controllers/stories_bulk_destroy_controller_spec.rb
+++ b/spec/controllers/stories_bulk_destroy_controller_spec.rb
@@ -37,8 +37,11 @@ describe StoriesBulkDestroyController do
     end
 
     context 'when bulk destroy fails' do
+      let(:story_operations_destroy_all_instance) { StoryOperations::DestroyAll.new }
+
       before do
-        allow(StoryOperations::DestroyAll).to receive(:call).and_return(false)
+        allow(StoryOperations::DestroyAll).to receive(:new).and_return(story_operations_destroy_all_instance)
+        allow(story_operations_destroy_all_instance).to receive(:call).and_return(Dry::Monads::Failure(false))
         post :create, params: { project_id: project.id, story_ids: [story_1.id, story_2.id] }
       end
 


### PR DESCRIPTION
Refactor StoryOperations::DestroyAll to use [dry-monads](https://github.com/dry-rb/dry-monads) and [dry-matcher](https://github.com/dry-rb/dry-matcher), making use of variables and calls clearer.