### PR TITLE
Refactor/StoryOperations::ReadAll

### DIFF
--- a/app/controllers/project_boards_controller.rb
+++ b/app/controllers/project_boards_controller.rb
@@ -1,7 +1,9 @@
 class ProjectBoardsController < ApplicationController
   def show
     authorize project
-    project_board = StoryOperations::ReadAll.call(project: project)
+
+    result = StoryOperations::ReadAll.new.call(project: project)
+    project_board = result.value!
 
     render json: project_board
   end

--- a/app/operations/beta/project_board_operations.rb
+++ b/app/operations/beta/project_board_operations.rb
@@ -47,7 +47,7 @@ module Beta
       end
 
       def stories_and_past_iterations
-        read_all_response = ::StoryOperations::ReadAll.call(project: project)
+        read_all_response = ::StoryOperations::ReadAll.new.call(project: project)
         read_all_response[:stories] = read_all_response.delete(:active_stories)
         read_all_response
       end

--- a/app/operations/story_operations.rb
+++ b/app/operations/story_operations.rb
@@ -239,12 +239,12 @@ module StoryOperations
       @project = project
 
       yield active_stories
-      yield get_project_iterations
+      yield project_iterations
 
-      Success({
+      Success(
         active_stories: @active_stories,
         past_iterations: past_iterations
-      })
+      )
     end
 
     private
@@ -255,7 +255,7 @@ module StoryOperations
       @project_iterations ||= Iterations::ProjectIterations.new(project: project)
     end
 
-    def get_project_iterations
+    def project_iterations
       @project_iterations ||= iterations
       Success(@project_iterations)
     end

--- a/spec/operations/beta/project_board_operations_spec.rb
+++ b/spec/operations/beta/project_board_operations_spec.rb
@@ -13,16 +13,10 @@ describe Beta::ProjectBoardOperations do
 
       let(:user) { create(:user, :with_team) }
 
-      let(:story_operations_read_all_instance) { StoryOperations::ReadAll.new }
+      let(:story_operations_read_all_instance) { instance_double(StoryOperations::ReadAll, call: { active_stories: stories, past_iterations: 'Past Iterations' }) }
 
       before do
         allow(StoryOperations::ReadAll).to receive(:new).and_return(story_operations_read_all_instance)
-        allow(story_operations_read_all_instance)
-          .to receive(:call).with(project: project)
-          .and_return(
-            active_stories: stories,
-            past_iterations: 'Past Iterations'
-          )
       end
 
       it 'returns all the project board data' do

--- a/spec/operations/beta/project_board_operations_spec.rb
+++ b/spec/operations/beta/project_board_operations_spec.rb
@@ -13,8 +13,11 @@ describe Beta::ProjectBoardOperations do
 
       let(:user) { create(:user, :with_team) }
 
+      let(:story_operations_read_all_instance) { StoryOperations::ReadAll.new }
+
       before do
-        allow(StoryOperations::ReadAll)
+        allow(StoryOperations::ReadAll).to receive(:new).and_return(story_operations_read_all_instance)
+        allow(story_operations_read_all_instance)
           .to receive(:call).with(project: project)
           .and_return(
             active_stories: stories,

--- a/spec/operations/story_operations_spec.rb
+++ b/spec/operations/story_operations_spec.rb
@@ -470,8 +470,8 @@ describe StoryOperations do
                                     points: done_story.estimate)
     end
 
-    subject      { StoryOperations::ReadAll }
-    let(:result) { subject.call(project: project) }
+    subject      { StoryOperations::ReadAll.new }
+    let(:result) { subject.call(project: project).value! }
 
     context 'when there are stories in the done column' do
       let(:project) { create(:project, :with_past_iteration, users: [user], teams: [current_team]) }


### PR DESCRIPTION
Refactor StoryOperations::ReadAll to use [dry-monads](https://github.com/dry-rb/dry-monads) and [dry-matcher](https://github.com/dry-rb/dry-matcher), making use of variables and calls clearer.