### PR TITLE
Chore/update migrations

### DIFF
--- a/db/migrate/20110210082458_devise_create_users.rb
+++ b/db/migrate/20110210082458_devise_create_users.rb
@@ -2,28 +2,30 @@ class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email, limit: 255, null: false, default: ""
+      t.string :encrypted_password, limit: 128, null: false, default: ""
+      t.string :password_salt, limit: 255
 
       ## Recoverable
-      t.string   :reset_password_token
+      t.string   :reset_password_token, limit: 255
       t.datetime :reset_password_sent_at
 
       ## Rememberable
+      t.string  :remember_token, limit: 255
       t.datetime :remember_created_at
 
       ## Trackable
       t.integer  :sign_in_count, default: 0
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.string   :current_sign_in_ip
-      t.string   :last_sign_in_ip
+      t.string   :current_sign_in_ip, limit: 255
+      t.string   :last_sign_in_ip, limit: 255
 
       ## Confirmable
-      t.string   :confirmation_token
+      t.string   :confirmation_token, limit: 255
       t.datetime :confirmed_at
       t.datetime :confirmation_sent_at
-      t.string   :unconfirmed_email # Only if using reconfirmable
+      # t.string   :unconfirmed_email # Only if using reconfirmable
 
       # t.encryptable
       # t.lockable lock_strategy: :failed_attempts, unlock_strategy: :both

--- a/db/migrate/20110210091929_create_projects.rb
+++ b/db/migrate/20110210091929_create_projects.rb
@@ -1,8 +1,8 @@
 class CreateProjects < ActiveRecord::Migration[4.2]
   def self.up
     create_table :projects do |t|
-      t.string :name
-      t.string :point_scale, default: 'fibonacci'
+      t.string :name, limit: 255
+      t.string :point_scale, limit: 255, default: 'fibonacci'
       t.date :start_date
       t.integer :iteration_start_day, default: 1
       t.integer :iteration_length, default: 1

--- a/db/migrate/20110412083637_create_stories.rb
+++ b/db/migrate/20110412083637_create_stories.rb
@@ -1,11 +1,11 @@
 class CreateStories < ActiveRecord::Migration[4.2]
   def self.up
     create_table :stories do |t|
-      t.string :title
+      t.string :title, limit: 255
       t.text :description
       t.integer :estimate
-      t.string :story_type, default: 'feature'
-      t.string :state, default: 'unstarted'
+      t.string :story_type, limit: 255, default: 'feature'
+      t.string :state, limit: 255, default: 'unstarted'
       t.date :accepted_at
       t.integer :requested_by_id
       t.integer :owned_by_id

--- a/db/migrate/20110627083011_add_name_and_initials_to_users.rb
+++ b/db/migrate/20110627083011_add_name_and_initials_to_users.rb
@@ -1,7 +1,7 @@
 class AddNameAndInitialsToUsers < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :users, :name, :string
-    add_column :users, :initials, :string
+    add_column :users, :name, :string, limit: 255
+    add_column :users, :initials, :string, limit: 255
   end
 
   def self.down

--- a/db/migrate/20111005192846_add_labels_to_story.rb
+++ b/db/migrate/20111005192846_add_labels_to_story.rb
@@ -1,6 +1,6 @@
 class AddLabelsToStory < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :stories, :labels, :string
+    add_column :stories, :labels, :string, limit: 255
   end
 
   def self.down

--- a/db/migrate/20120504152649_add_locale_to_users.rb.rb
+++ b/db/migrate/20120504152649_add_locale_to_users.rb.rb
@@ -1,6 +1,6 @@
 class AddLocaleToUsers < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :users, :locale, :string
+    add_column :users, :locale, :string, limit: 255
   end
 
   def self.down

--- a/db/migrate/20150623185240_create_attachinary_tables.attachinary.rb
+++ b/db/migrate/20150623185240_create_attachinary_tables.attachinary.rb
@@ -2,15 +2,15 @@
 class CreateAttachinaryTables < ActiveRecord::Migration[4.2]
   def change
     create_table :attachinary_files do |t|
-      t.references :attachinariable, polymorphic: true
-      t.string :scope
-
-      t.string :public_id
-      t.string :version
+      t.integer  :attachinariable_id
+      t.string  :attachinariable_type, limit: 255
+      t.string :scope, limit: 255
+      t.string :public_id, limit: 255
+      t.string :version, limit: 255
       t.integer :width
       t.integer :height
-      t.string :format
-      t.string :resource_type
+      t.string :format, limit: 255
+      t.string :resource_type, limit: 255
       t.timestamps
     end
     add_index :attachinary_files, [:attachinariable_type, :attachinariable_id, :scope], name: 'by_scoped_parent'

--- a/db/migrate/20150625143900_not_found_user_names_for_story_and_notes.rb
+++ b/db/migrate/20150625143900_not_found_user_names_for_story_and_notes.rb
@@ -1,9 +1,9 @@
 class NotFoundUserNamesForStoryAndNotes < ActiveRecord::Migration[4.2]
   def change
-    add_column :stories, :requested_by_name, :string
-    add_column :stories, :owned_by_name, :string
-    add_column :stories, :owned_by_initials, :string
-    add_column :notes, :user_name, :string
+    add_column :stories, :requested_by_name, :string, limit: 255
+    add_column :stories, :owned_by_name, :string, limit: 255
+    add_column :stories, :owned_by_initials, :string, limit: 255
+    add_column :notes, :user_name, :string,  limit: 255
 
     Story.find_each do |s|
       s.requested_by_name = s.requested_by.try(:name)

--- a/db/migrate/20150626134654_add_slug_to_project.rb
+++ b/db/migrate/20150626134654_add_slug_to_project.rb
@@ -1,6 +1,6 @@
 class AddSlugToProject < ActiveRecord::Migration[4.2]
   def change
-    add_column :projects, :slug, :string
+    add_column :projects, :slug, :string, limit: 255
     add_index :projects, :slug, unique: true
   end
 end

--- a/db/migrate/20160616195841_create_tasks.rb
+++ b/db/migrate/20160616195841_create_tasks.rb
@@ -2,7 +2,7 @@ class CreateTasks < ActiveRecord::Migration[4.2]
   def self.up
     create_table :tasks do |t|
       t.references :story
-      t.string :name
+      t.string :name, limit: 255
       t.boolean :done, default: false
 
       t.timestamps

--- a/db/migrate/20160628195845_add_username_to_users.rb
+++ b/db/migrate/20160628195845_add_username_to_users.rb
@@ -1,6 +1,6 @@
 class AddUsernameToUsers < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :users, :username, :string, null: false, default: ''
+    add_column :users, :username, :string, limit: 255, null: false, default: ''
   end
 
   def self.down

--- a/db/migrate/20160818013050_create_integrations.rb
+++ b/db/migrate/20160818013050_create_integrations.rb
@@ -1,10 +1,11 @@
 class CreateIntegrations < ActiveRecord::Migration[4.2]
   def change
     enable_extension "hstore"
+    enable_extension "pg_stat_statements"
 
     create_table :integrations do |t|
-      t.belongs_to :project, foreign_key: true
-      t.string :kind, null: false
+      t.belongs_to :project
+      t.string :kind, limit: 255, null: false
       t.hstore :data, null: false
 
       t.timestamps

--- a/db/migrate/20160825181243_create_activities.rb
+++ b/db/migrate/20160825181243_create_activities.rb
@@ -4,10 +4,10 @@ class CreateActivities < ActiveRecord::Migration[4.2]
       t.references :project, null: false
       t.references :user, null: false
       t.integer :subject_id
-      t.string :subject_type
-      t.string :action
+      t.string :subject_type, limit: 255
+      t.string :action, limit: 255
       t.text :subject_changes, default: nil
-      t.string :subject_destroyed_type
+      t.string :subject_destroyed_type, limit: 255
 
       t.timestamps
     end

--- a/db/migrate/20160831134320_add_time_zone_to_users.rb
+++ b/db/migrate/20160831134320_add_time_zone_to_users.rb
@@ -1,5 +1,5 @@
 class AddTimeZoneToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :time_zone, :string, null: false, default: 'Brasilia'
+    add_column :users, :time_zone, :string, limit: 255, null: false, default: 'Brasilia'
   end
 end

--- a/db/migrate/20160904163037_create_teams.rb
+++ b/db/migrate/20160904163037_create_teams.rb
@@ -1,9 +1,9 @@
 class CreateTeams < ActiveRecord::Migration[4.2]
   def up
     create_table :teams do |t|
-      t.string :name, null: false
-      t.string :slug
-      t.string :logo
+      t.string :name, limit: 255, null: false
+      t.string :slug, limit: 255
+      t.string :logo, limit: 255
       t.datetime :archived_at
 
       t.timestamps

--- a/db/migrate/20160904163124_create_enrollments.rb
+++ b/db/migrate/20160904163124_create_enrollments.rb
@@ -7,8 +7,8 @@ class CreateEnrollments < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_foreign_key :enrollments, :teams, dependent: :delete
-    add_foreign_key :enrollments, :users, dependent: :delete
+    add_foreign_key :enrollments, :teams, name: "enrollments_team_id_fk", on_delete: :cascade
+    add_foreign_key :enrollments, :users, name: "enrollments_user_id_fk", on_delete: :cascade
     add_index :enrollments, [:team_id, :user_id], unique: true
 
     unless Rails.env.production?
@@ -21,8 +21,8 @@ class CreateEnrollments < ActiveRecord::Migration[4.2]
 
   def down
     remove_index :enrollments, [:team_id, :user_id]
-    remove_foreign_key :enrollments, :teams
-    remove_foreign_key :enrollments, :users
+    remove_foreign_key :enrollments, :teams, name: "enrollments_team_id_fk"
+    remove_foreign_key :enrollments, :users, name: "enrollments_user_id_fk"
     drop_table :enrollments
   end
 end

--- a/db/migrate/20160904163158_create_ownerships.rb
+++ b/db/migrate/20160904163158_create_ownerships.rb
@@ -7,8 +7,8 @@ class CreateOwnerships < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_foreign_key :ownerships, :teams, dependent: :delete
-    add_foreign_key :ownerships, :projects, dependent: :delete
+    add_foreign_key :ownerships, :teams, name: "ownerships_team_id_fk", on_delete: :cascade
+    add_foreign_key :ownerships, :projects, name: "ownerships_project_id_fk", on_delete: :cascade
     add_index :ownerships, [:team_id, :project_id], unique: true
 
     unless Rails.env.production?
@@ -21,8 +21,8 @@ class CreateOwnerships < ActiveRecord::Migration[4.2]
 
   def down
     remove_index :ownerships, [:team_id, :project_id]
-    remove_foreign_key :ownerships, :teams
-    remove_foreign_key :ownerships, :projects
+    remove_foreign_key :ownerships, :teams, name: "ownerships_team_id_fk"
+    remove_foreign_key :ownerships, :projects, name: "ownerships_project_id_fk"
     drop_table :ownerships
   end
 end

--- a/db/migrate/20160905131732_add_keys.rb
+++ b/db/migrate/20160905131732_add_keys.rb
@@ -5,12 +5,12 @@ class AddKeys < ActiveRecord::Migration[4.2]
     Note.where("story_id not in (?)", Story.all.pluck(:id)).delete_all
     Task.where("story_id not in (?)", Story.all.pluck(:id)).delete_all
 
-    add_foreign_key "integrations", "projects", name: "integrations_project_id_fk", dependent: :delete
-    add_foreign_key "memberships", "projects", name: "memberships_project_id_fk", dependent: :delete
-    add_foreign_key "memberships", "users", name: "memberships_user_id_fk", dependent: :delete
-    add_foreign_key "notes", "stories", name: "notes_story_id_fk", dependent: :delete
-    add_foreign_key "stories", "projects", name: "stories_project_id_fk", dependent: :delete
-    add_foreign_key "tasks", "stories", name: "tasks_story_id_fk", dependent: :delete
+    add_foreign_key "integrations", "projects", name: "integrations_project_id_fk", on_delete: :cascade
+    add_foreign_key "memberships", "projects", name: "memberships_project_id_fk", on_delete: :cascade
+    add_foreign_key "memberships", "users", name: "memberships_user_id_fk", on_delete: :cascade
+    add_foreign_key "notes", "stories", name: "notes_story_id_fk", on_delete: :cascade
+    add_foreign_key "stories", "projects", name: "stories_project_id_fk", on_delete: :cascade
+    add_foreign_key "tasks", "stories", name: "tasks_story_id_fk", on_delete: :cascade
   end
 
   def down

--- a/db/migrate/20160905190120_move_disable_registration_to_team.rb
+++ b/db/migrate/20160905190120_move_disable_registration_to_team.rb
@@ -1,7 +1,7 @@
 class MoveDisableRegistrationToTeam < ActiveRecord::Migration[4.2]
   def change
     add_column :teams, :disable_registration, :boolean, null: false, default: false
-    add_column :teams, :registration_domain_whitelist, :string
-    add_column :teams, :registration_domain_blacklist, :string
+    add_column :teams, :registration_domain_whitelist, :string, limit: 255
+    add_column :teams, :registration_domain_blacklist, :string, limit: 255
   end
 end

--- a/db/migrate/20160912135322_devise_create_admin_users.rb
+++ b/db/migrate/20160912135322_devise_create_admin_users.rb
@@ -2,11 +2,11 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:admin_users) do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email, limit: 255, null: false, default: ""
+      t.string :encrypted_password, limit: 255, null: false, default: ""
 
       ## Recoverable
-      t.string   :reset_password_token
+      t.string   :reset_password_token, limit: 255
       t.datetime :reset_password_sent_at
 
       ## Rememberable

--- a/db/migrate/20160912135326_create_active_admin_comments.rb
+++ b/db/migrate/20160912135326_create_active_admin_comments.rb
@@ -1,11 +1,12 @@
 class CreateActiveAdminComments < ActiveRecord::Migration[4.2]
   def self.up
     create_table :active_admin_comments do |t|
-      t.string :namespace
+      t.string :namespace, limit: 255
       t.text   :body
-      t.string :resource_id,   null: false
-      t.string :resource_type, null: false
-      t.references :author, polymorphic: true
+      t.string :resource_id, limit: 255, null: false
+      t.string :resource_type, limit: 255, null: false
+      t.integer  :author_id
+      t.string  :author_type, limit: 255
       t.timestamps
     end
     add_index :active_admin_comments, [:namespace]

--- a/db/migrate/20170329211205_create_tag_groups.rb
+++ b/db/migrate/20170329211205_create_tag_groups.rb
@@ -5,6 +5,7 @@ class CreateTagGroups < ActiveRecord::Migration[4.2]
       t.string :name, limit: 15
       t.text :description
       t.string :bg_color, default: "#2075F3"
+      t.string :foreground_color
       t.timestamps null: false
     end
   end


### PR DESCRIPTION
This pull request is related to the issue [#875](https://github.com/Codeminer42/cm42-central/issues/875). The goal is to update all migrations to ensure that when the database is created from scratch, the schema matches the one currently used in production.

I have modified the old migrations so that now, when the database is created using the migrate command, it generates the same schema.

Here is a comparison between the schema created by the updated migrations and the one currently in the repository: [Schema comparison](https://www.diffchecker.com/rkylIDKI/).