### PR TITLE
MUCH faster RSpec feature bootup

### DIFF
--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    `bundle exec rake assets:precompile`
+    ViteRuby.commands.build
   end
 
   config.around(:each) do |ex|


### PR DESCRIPTION
This one-liner speeds up a single RSpec feature run from almost 2 minutes to just 8 seconds on my development machine!

I'm honestly not sure why its THAT much faster. Avoiding an unnecessary additional reload of the entire Rails environment is an obvious ~6s win, but something more was clearly wrong with this original strategy. Maybe it was interacting weirdly with RSpec's automatic retry functionality or something? I suppose it doesn't really matter, its better now.