### PR TITLE
Fixes emails not being sent because of queue name mismatch

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:verbose: false
-:queues:
+verbose: false
+queues:
   - default
-  - mailer
+  - mailers


### PR DESCRIPTION
The ActiveJob mailer queue name is "mailers", not "mailer." This fixes all emails queued with `deliver_later` not being sent.