### PR TITLE
Deliver notes mention email asynchronously

### DIFF
--- a/app/operations/note_operations/user_notification.rb
+++ b/app/operations/note_operations/user_notification.rb
@@ -14,8 +14,7 @@ module NoteOperations
       return if note.story.suppress_notifications
       return if users_to_notify.none?
 
-      notifier = Notifications.new_note(note.id, users_to_notify.map(&:email))
-      notifier&.deliver
+      Notifications.new_note(note.id, users_to_notify.map(&:email)).deliver_later
     end
 
     private

--- a/spec/operations/note_operations/user_notification_spec.rb
+++ b/spec/operations/note_operations/user_notification_spec.rb
@@ -19,7 +19,7 @@ describe NoteOperations::UserNotification do
 
     it 'sends notification', :aggregate_failures do
       expect(Notifications).to receive(:new_note).with(note.id, users_to_notify).and_return(notifier)
-      expect(notifier).to receive(:deliver)
+      expect(notifier).to receive(:deliver_later)
 
       subject.call
     end
@@ -59,7 +59,7 @@ describe NoteOperations::UserNotification do
 
       it 'sends notitication to the mentioned user', :aggregate_failures do
         expect(Notifications).to receive(:new_note).with(note.id, users_to_notify).and_return(notifier)
-        expect(notifier).to receive(:deliver)
+        expect(notifier).to receive(:deliver_later)
 
         subject.call
       end


### PR DESCRIPTION
Looks like a lingering `deliver` not updated to `deliver_later` with the rest of them.

Also, the nil check is unnecessary, because deliver methods can never return nil. Just to make sure, I dug through the history and there seemed to never be a reason to introduce this nil check.