### PR TITLE
migrate components/story/expanded_story tests from Enzyme to testing-library

### DIFF
--- a/spec/javascripts/components/story/collapsed_story/collapsed_story_actions_spec.js
+++ b/spec/javascripts/components/story/collapsed_story/collapsed_story_actions_spec.js
@@ -1,31 +1,27 @@
 import { render, screen } from '@testing-library/react';
 import CollapsedStoryStateActions from 'components/story/CollapsedStory/CollapsedStoryStateActions';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 import { describe, it } from 'vitest';
 import storyFactory from '../../../support/factories/storyFactory';
-
-const mockReducer = (state = {}, action) => state;
-const createMockStore = (initialState = {}) => {
-  return createStore(mockReducer, initialState);
-};
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<CollapsedStoryStateActions />', () => {
+  const renderComponent = props => {
+    const defaultProps = { story: { estimate: null } };
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<CollapsedStoryStateActions {...mergedProps} />);
+  };
+
   describe('When estimate is null', () => {
     it('renders <CollapsedStoryStateActions /> component', () => {
-      const props = storyFactory({ estimate: null });
-      const mockStore = createMockStore({
+      const props = {
         project: {
           pointValues: [1, 2, 3, 5, 8],
         },
-      });
+      };
 
-      const { container } = render(
-        <Provider store={mockStore}>
-          <CollapsedStoryStateActions story={props} />
-        </Provider>
-      );
+      const { container } = renderComponent(props);
 
       expect(container).toBeInTheDocument();
     });
@@ -44,17 +40,12 @@ describe('<CollapsedStoryStateActions />', () => {
     states.forEach(({ state, actions }) => {
       describe(`When state = ${state}`, () => {
         it('renders the <CollapsedStoryStateButton /> component', () => {
-          const props = storyFactory({ state });
-          const mockStore = createMockStore({
-            project: {
-              pointValues: [1, 2, 3, 5, 8],
-            },
-          });
-          render(
-            <Provider store={mockStore}>
-              <CollapsedStoryStateActions story={props} />
-            </Provider>
-          );
+          const props = {
+            story: storyFactory({ state }),
+            project: { pointValues: [1, 2, 3, 5, 8] },
+          };
+
+          renderComponent(props);
 
           actions.forEach(action => {
             const stateButtons = screen.getAllByText(action, { exact: false });

--- a/spec/javascripts/components/story/collapsed_story/collapsed_story_spec.js
+++ b/spec/javascripts/components/story/collapsed_story/collapsed_story_spec.js
@@ -1,48 +1,53 @@
-import { render } from '@testing-library/react';
 import { Container as CollapsedStory } from 'components/story/CollapsedStory/index';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 import { expect, vi } from 'vitest';
 import storyFactory from '../../../support/factories/storyFactory';
-
-const mockReducer = (state = {}, action) => state;
-const createMockStore = (initialState = {}) => {
-  return createStore(mockReducer, initialState);
-};
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<CollapsedStory />', () => {
   vi.spyOn(window.md, 'makeHtml').mockReturnValue('<p>Test</p>');
 
-  const defaultProps = () => ({
-    story: {},
-    onToggle: vi.fn(),
-    title: '',
-    className: '',
-    from: 'all',
-    highlight: vi.fn(),
-    stories: {
-      all: [],
-      search: [],
-    },
-    provided: {
-      draggableProps: {
-        style: {},
+  const renderComponent = props => {
+    const defaultProps = {
+      story: {},
+      onToggle: vi.fn(),
+      title: '',
+      className: '',
+      from: 'all',
+      highlight: vi.fn(),
+      stories: {
+        all: [],
+        search: [],
       },
-    },
-    snapshot: {
-      isDragging: false,
-    },
-    onLabelClick: vi.fn(),
-  });
+      provided: {
+        draggableProps: {
+          style: {},
+        },
+      },
+      snapshot: {
+        isDragging: false,
+      },
+      onLabelClick: vi.fn(),
+    };
+
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<CollapsedStory {...mergedProps} />, {
+      preloadedState: {
+        project: {
+          pointValues: [],
+        },
+      },
+    });
+  };
 
   describe("when estimate isn't null", () => {
     it('renders the component with Story--estimated className', () => {
-      const story = storyFactory({ storyType: 'feature', estimate: 1 });
+      const props = {
+        story: storyFactory({ storyType: 'feature', estimate: 1 }),
+      };
 
-      const { container } = render(
-        <CollapsedStory {...defaultProps()} story={story} />
-      );
+      const { container } = renderComponent(props);
 
       expect(container.firstChild).toHaveClass('Story--estimated');
     });
@@ -50,18 +55,11 @@ describe('<CollapsedStory />', () => {
 
   describe('when estimate is null', () => {
     it('renders the component with Story--unestimated className', () => {
-      const story = storyFactory({ storyType: 'feature', estimate: null });
-      const mockStore = createMockStore({
-        project: {
-          pointValues: [1, 2, 3, 5, 8],
-        },
-      });
+      const props = {
+        story: storyFactory({ storyType: 'feature', estimate: null }),
+      };
 
-      const { container } = render(
-        <Provider store={mockStore}>
-          <CollapsedStory {...defaultProps()} story={story} />
-        </Provider>
-      );
+      const { container } = renderComponent(props);
 
       expect(container.firstChild).toHaveClass('Story--unestimated');
     });
@@ -69,22 +67,22 @@ describe('<CollapsedStory />', () => {
 
   describe('when storyType = release', () => {
     it('renders the component with Story--release className', () => {
-      const story = storyFactory({ storyType: 'release' });
+      const props = {
+        story: storyFactory({ storyType: 'release' }),
+      };
 
-      const { container } = render(
-        <CollapsedStory {...defaultProps()} story={story} />
-      );
+      const { container } = renderComponent(props);
 
       expect(container.firstChild).toHaveClass('Story--release');
     });
   });
 
   it('renders children components', () => {
-    const story = storyFactory({ storyType: 'feature', estimate: 1 });
+    const props = {
+      story: storyFactory({ storyType: 'feature', estimate: 1 }),
+    };
 
-    const { container } = render(
-      <CollapsedStory {...defaultProps()} story={story} />
-    );
+    const { container } = renderComponent(props);
 
     // StoryPopover
     const storyPopover = container.querySelector('.popover__content');

--- a/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
@@ -1,19 +1,18 @@
-import { screen } from '@testing-library/react';
 import { ExpandedStoryDefault } from 'components/story/ExpandedStory/ExpandedStoryDefault';
 import React from 'react';
-import { beforeAll } from 'vitest';
 import { createTemporaryId } from '../../../../../../app/assets/javascripts/models/beta/story';
 import storyFactory from '../../../../support/factories/storyFactory';
 import { renderWithProviders } from '../../../setupRedux';
 
-// this allows capture of elements without having to go through translations
-beforeAll(() => {
-  global.I18n = {
-    t: vi.fn().mockImplementation(arg => arg),
-  };
-});
-
 describe('<ExpandedStoryDefault />', () => {
+  beforeEach(function () {
+    vi.spyOn(I18n, 't');
+  });
+
+  afterEach(function () {
+    I18n.t.mockRestore();
+  });
+
   vi.spyOn(window.md, 'makeHtml').mockReturnValue('<p>Test</p>');
   vi.mock('react-clipboard.js', () => ({
     default: vi
@@ -50,8 +49,6 @@ describe('<ExpandedStoryDefault />', () => {
   };
 
   it("renders all children components when story isn't new", () => {
-    vi.mock('');
-
     const props = {
       story: {
         ...storyFactory({ id: 42 }),
@@ -67,60 +64,45 @@ describe('<ExpandedStoryDefault />', () => {
     expect(expandedStoryHistoryLocation).toBeInTheDocument();
 
     // ExpandedStoryTitle
-    const expandedStoryTitle = screen.getByText(
-      'activerecord.attributes.story.title'
-    );
-    expect(expandedStoryTitle).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.title');
 
     // ExpandedStoryEstimate
-    const expandedStoryEstimate = screen.getByText(
+
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.estimate'
     );
-    expect(expandedStoryEstimate).toBeInTheDocument();
 
     // ExpandedStoryType
-    const expandedStoryType = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.story_type'
     );
-    expect(expandedStoryType).toBeInTheDocument();
 
     // ExpandedStoryState
-    const expandedStoryState = screen.getByText(
-      'activerecord.attributes.story.state'
-    );
-    expect(expandedStoryState).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.state');
 
     // ExpandedStoryRequestedBy
-    const expandedStoryRequestedBy = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.requested_by'
     );
-    expect(expandedStoryRequestedBy).toBeInTheDocument();
 
     // ExpandedStoryOwnedBy
-    const expandedStoryOwnedBy = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.owned_by'
     );
-    expect(expandedStoryOwnedBy).toBeInTheDocument();
 
     // ExpandedStoryLabels
-    const expandedStoryLabels = screen.getByText(
-      'activerecord.attributes.story.labels'
-    );
-    expect(expandedStoryLabels).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.labels');
 
     // ExpandedStoryDescription
-    const expandedStoryDescription = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.description'
     );
-    expect(expandedStoryDescription).toBeInTheDocument();
 
     // ExpandedStoryTask
-    const expandedStoryTask = screen.getByText('story.tasks');
-    expect(expandedStoryTask).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('story.tasks');
 
     // ExpandedStoryNotes
-    const expandedStoryNotes = screen.getByText('add note');
-    expect(expandedStoryNotes).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('add note');
   });
 
   it('does not render some components when it is a new story', () => {
@@ -140,59 +122,44 @@ describe('<ExpandedStoryDefault />', () => {
     expect(expandedStoryHistoryLocation).toBeNull();
 
     // ExpandedStoryTitle
-    const expandedStoryTitle = screen.getByText(
-      'activerecord.attributes.story.title'
-    );
-    expect(expandedStoryTitle).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.title');
 
     // ExpandedStoryEstimate
-    const expandedStoryEstimate = screen.getByText(
+
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.estimate'
     );
-    expect(expandedStoryEstimate).toBeInTheDocument();
 
     // ExpandedStoryType
-    const expandedStoryType = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.story_type'
     );
-    expect(expandedStoryType).toBeInTheDocument();
 
     // ExpandedStoryState
-    const expandedStoryState = screen.getByText(
-      'activerecord.attributes.story.state'
-    );
-    expect(expandedStoryState).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.state');
 
     // ExpandedStoryRequestedBy
-    const expandedStoryRequestedBy = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.requested_by'
     );
-    expect(expandedStoryRequestedBy).toBeInTheDocument();
 
     // ExpandedStoryOwnedBy
-    const expandedStoryOwnedBy = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.owned_by'
     );
-    expect(expandedStoryOwnedBy).toBeInTheDocument();
 
     // ExpandedStoryLabels
-    const expandedStoryLabels = screen.getByText(
-      'activerecord.attributes.story.labels'
-    );
-    expect(expandedStoryLabels).toBeInTheDocument();
+    expect(I18n.t).toHaveBeenCalledWith('activerecord.attributes.story.labels');
 
     // ExpandedStoryDescription
-    const expandedStoryDescription = screen.getByText(
+    expect(I18n.t).toHaveBeenCalledWith(
       'activerecord.attributes.story.description'
     );
-    expect(expandedStoryDescription).toBeInTheDocument();
 
     // ExpandedStoryTask
-    const expandedStoryTask = screen.queryByText('story.tasks');
-    expect(expandedStoryTask).toBeNull();
+    expect(I18n.t).not.toHaveBeenCalledWith('story.tasks');
 
     // ExpandedStoryNotes
-    const expandedStoryNotes = screen.queryByText('add note');
-    expect(expandedStoryNotes).toBeNull();
+    expect(I18n.t).not.toHaveBeenCalledWith('add note');
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_default/expanded_story_default_spec.js
@@ -1,77 +1,198 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
 import { ExpandedStoryDefault } from 'components/story/ExpandedStory/ExpandedStoryDefault';
-import storyFactory from '../../../../support/factories/storyFactory';
+import React from 'react';
+import { beforeAll } from 'vitest';
 import { createTemporaryId } from '../../../../../../app/assets/javascripts/models/beta/story';
+import storyFactory from '../../../../support/factories/storyFactory';
+import { renderWithProviders } from '../../../setupRedux';
+
+// this allows capture of elements without having to go through translations
+beforeAll(() => {
+  global.I18n = {
+    t: vi.fn().mockImplementation(arg => arg),
+  };
+});
 
 describe('<ExpandedStoryDefault />', () => {
-  const defaultProps = () => ({
-    story: {
-      ...storyFactory(),
-      _editing: storyFactory(),
-    },
-    onEdit: vi.fn(),
-    storyFailure: vi.fn(),
-    createTask: vi.fn(),
-    deleteTask: vi.fn(),
-    toggleTask: vi.fn(),
-    deleteNote: vi.fn(),
-    createNote: vi.fn(),
-    addLabel: vi.fn(),
-    removeLabel: vi.fn(),
-    setLoadingStory: vi.fn(),
-    users: [],
-    project: { labels: [] },
-    enabled: true,
-    onClone: vi.fn(),
-    showHistory: vi.fn(),
-    disabled: false,
-  });
+  vi.spyOn(window.md, 'makeHtml').mockReturnValue('<p>Test</p>');
+  vi.mock('react-clipboard.js', () => ({
+    default: vi
+      .fn()
+      .mockImplementation(({ children }) => <div>{children}</div>),
+  }));
 
-  it("renders all children components when isn't a new story", () => {
-    const story = {
-      ...storyFactory({ id: 42 }),
-      _editing: storyFactory({ id: 42 }),
+  const renderComponent = props => {
+    const defaultProps = {
+      story: {
+        ...storyFactory(),
+        _editing: storyFactory(),
+      },
+      onEdit: vi.fn(),
+      storyFailure: vi.fn(),
+      createTask: vi.fn(),
+      deleteTask: vi.fn(),
+      toggleTask: vi.fn(),
+      deleteNote: vi.fn(),
+      createNote: vi.fn(),
+      addLabel: vi.fn(),
+      removeLabel: vi.fn(),
+      setLoadingStory: vi.fn(),
+      users: [],
+      project: { pointValues: [], labels: [] },
+      enabled: true,
+      onClone: vi.fn(),
+      showHistory: vi.fn(),
+      disabled: false,
+    };
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryDefault {...mergedProps} />);
+  };
+
+  it("renders all children components when story isn't new", () => {
+    vi.mock('');
+
+    const props = {
+      story: {
+        ...storyFactory({ id: 42 }),
+        _editing: storyFactory({ id: 42 }),
+      },
     };
 
-    const wrapper = shallow(
-      <ExpandedStoryDefault {...defaultProps()} story={story} />
-    );
+    const { container } = renderComponent(props);
 
-    expect(wrapper.find('ExpandedStoryHistoryLocation')).toExist();
-    expect(wrapper.find('ExpandedStoryTitle')).toExist();
-    expect(wrapper.find('ExpandedStoryEstimate')).toExist();
-    expect(wrapper.find('ExpandedStoryType')).toExist();
-    expect(wrapper.find('ExpandedStoryState')).toExist();
-    expect(wrapper.find('ExpandedStoryRequestedBy')).toExist();
-    expect(wrapper.find('ExpandedStoryOwnedBy')).toExist();
-    expect(wrapper.find('ExpandedStoryLabels')).toExist();
-    expect(wrapper.find('ExpandedStoryDescription')).toExist();
-    expect(wrapper.find('ExpandedStoryTask')).toExist();
-    expect(wrapper.find('ExpandedStoryNotes')).toExist();
+    // ExpandedStoryHistoryLocation
+    const expandedStoryHistoryLocation =
+      container.querySelector('#story-link-42');
+    expect(expandedStoryHistoryLocation).toBeInTheDocument();
+
+    // ExpandedStoryTitle
+    const expandedStoryTitle = screen.getByText(
+      'activerecord.attributes.story.title'
+    );
+    expect(expandedStoryTitle).toBeInTheDocument();
+
+    // ExpandedStoryEstimate
+    const expandedStoryEstimate = screen.getByText(
+      'activerecord.attributes.story.estimate'
+    );
+    expect(expandedStoryEstimate).toBeInTheDocument();
+
+    // ExpandedStoryType
+    const expandedStoryType = screen.getByText(
+      'activerecord.attributes.story.story_type'
+    );
+    expect(expandedStoryType).toBeInTheDocument();
+
+    // ExpandedStoryState
+    const expandedStoryState = screen.getByText(
+      'activerecord.attributes.story.state'
+    );
+    expect(expandedStoryState).toBeInTheDocument();
+
+    // ExpandedStoryRequestedBy
+    const expandedStoryRequestedBy = screen.getByText(
+      'activerecord.attributes.story.requested_by'
+    );
+    expect(expandedStoryRequestedBy).toBeInTheDocument();
+
+    // ExpandedStoryOwnedBy
+    const expandedStoryOwnedBy = screen.getByText(
+      'activerecord.attributes.story.owned_by'
+    );
+    expect(expandedStoryOwnedBy).toBeInTheDocument();
+
+    // ExpandedStoryLabels
+    const expandedStoryLabels = screen.getByText(
+      'activerecord.attributes.story.labels'
+    );
+    expect(expandedStoryLabels).toBeInTheDocument();
+
+    // ExpandedStoryDescription
+    const expandedStoryDescription = screen.getByText(
+      'activerecord.attributes.story.description'
+    );
+    expect(expandedStoryDescription).toBeInTheDocument();
+
+    // ExpandedStoryTask
+    const expandedStoryTask = screen.getByText('story.tasks');
+    expect(expandedStoryTask).toBeInTheDocument();
+
+    // ExpandedStoryNotes
+    const expandedStoryNotes = screen.getByText('add note');
+    expect(expandedStoryNotes).toBeInTheDocument();
   });
 
-  it('not renders some components when it is a new story', () => {
+  it('does not render some components when it is a new story', () => {
     const id = createTemporaryId();
-    const story = {
-      ...storyFactory({ id }),
-      _editing: storyFactory({ id }),
+    const props = {
+      story: {
+        ...storyFactory({ id }),
+        _editing: storyFactory({ id }),
+      },
     };
 
-    const wrapper = shallow(
-      <ExpandedStoryDefault {...defaultProps()} story={story} />
-    );
+    const { container } = renderComponent(props);
 
-    expect(wrapper.find('ExpandedStoryHistoryLocation')).not.toExist();
-    expect(wrapper.find('ExpandedStoryTitle')).toExist();
-    expect(wrapper.find('ExpandedStoryEstimate')).toExist();
-    expect(wrapper.find('ExpandedStoryType')).toExist();
-    expect(wrapper.find('ExpandedStoryState')).toExist();
-    expect(wrapper.find('ExpandedStoryRequestedBy')).toExist();
-    expect(wrapper.find('ExpandedStoryOwnedBy')).toExist();
-    expect(wrapper.find('ExpandedStoryLabels')).toExist();
-    expect(wrapper.find('ExpandedStoryDescription')).toExist();
-    expect(wrapper.find('ExpandedStoryTask')).not.toExist();
-    expect(wrapper.find('ExpandedStoryNotes')).not.toExist();
+    // ExpandedStoryHistoryLocation
+    const expandedStoryHistoryLocation =
+      container.querySelector('#story-link-42');
+    expect(expandedStoryHistoryLocation).toBeNull();
+
+    // ExpandedStoryTitle
+    const expandedStoryTitle = screen.getByText(
+      'activerecord.attributes.story.title'
+    );
+    expect(expandedStoryTitle).toBeInTheDocument();
+
+    // ExpandedStoryEstimate
+    const expandedStoryEstimate = screen.getByText(
+      'activerecord.attributes.story.estimate'
+    );
+    expect(expandedStoryEstimate).toBeInTheDocument();
+
+    // ExpandedStoryType
+    const expandedStoryType = screen.getByText(
+      'activerecord.attributes.story.story_type'
+    );
+    expect(expandedStoryType).toBeInTheDocument();
+
+    // ExpandedStoryState
+    const expandedStoryState = screen.getByText(
+      'activerecord.attributes.story.state'
+    );
+    expect(expandedStoryState).toBeInTheDocument();
+
+    // ExpandedStoryRequestedBy
+    const expandedStoryRequestedBy = screen.getByText(
+      'activerecord.attributes.story.requested_by'
+    );
+    expect(expandedStoryRequestedBy).toBeInTheDocument();
+
+    // ExpandedStoryOwnedBy
+    const expandedStoryOwnedBy = screen.getByText(
+      'activerecord.attributes.story.owned_by'
+    );
+    expect(expandedStoryOwnedBy).toBeInTheDocument();
+
+    // ExpandedStoryLabels
+    const expandedStoryLabels = screen.getByText(
+      'activerecord.attributes.story.labels'
+    );
+    expect(expandedStoryLabels).toBeInTheDocument();
+
+    // ExpandedStoryDescription
+    const expandedStoryDescription = screen.getByText(
+      'activerecord.attributes.story.description'
+    );
+    expect(expandedStoryDescription).toBeInTheDocument();
+
+    // ExpandedStoryTask
+    const expandedStoryTask = screen.queryByText('story.tasks');
+    expect(expandedStoryTask).toBeNull();
+
+    // ExpandedStoryNotes
+    const expandedStoryNotes = screen.queryByText('add note');
+    expect(expandedStoryNotes).toBeNull();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_description/expanded_story_description_content_area_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_description/expanded_story_description_content_area_spec.js
@@ -1,28 +1,30 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryContentArea from 'components/story/ExpandedStory/ExpandedStoryDescription/ExpandedStoryContentArea';
+import React from 'react';
+import { renderWithProviders } from '../../../setupRedux';
 
 describe('<ExpandedStoryContentArea />', () => {
-  const renderContent = propsOverride => {
-    const wrapper = shallow(
-      <ExpandedStoryContentArea
-        onClick={vi.fn()}
-        description=""
-        {...propsOverride}
-      />
-    );
-    const descriptionContent = wrapper.find('[data-id="description-content"]');
-    const editButton = wrapper.find('[data-id="edit-button"]');
+  const markdownSpy = vi
+    .spyOn(window.md, 'makeHtml')
+    .mockReturnValue('<p>Test</p>');
 
-    return { wrapper, descriptionContent, editButton };
+  const renderComponent = props => {
+    const defaultProps = {
+      onClick: vi.fn(),
+      description: '',
+    };
+
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryContentArea {...mergedProps} />);
   };
 
   describe("when description isn't null", () => {
     const description = 'description example';
 
     it('renders <ExpandedStoryDescriptionContent />', () => {
-      const { descriptionContent } = renderContent({ description });
-      expect(descriptionContent.exists()).toBeTruthy();
+      renderComponent({ description });
+
+      expect(markdownSpy).toHaveBeenCalledWith(description);
     });
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_description/expanded_story_description_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_description/expanded_story_description_spec.js
@@ -1,21 +1,25 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryDescription from 'components/story/ExpandedStory/ExpandedStoryDescription/index';
+import React from 'react';
+import { renderWithProviders } from '../../../setupRedux';
 
 describe('<ExpandedStoryDescription />', () => {
-  const defaultProps = () => ({
-    story: {},
-    onEdit: vi.fn(),
-    disabled: false,
-  });
+  const renderComponent = props => {
+    const defaultProps = {
+      story: {},
+      onEdit: vi.fn(),
+      disabled: false,
+    };
+
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryDescription {...mergedProps} />);
+  };
 
   it('renders component', () => {
-    const story = { description: '', _editing: { description: '' } };
+    const props = { story: { description: '', _editing: { description: '' } } };
 
-    const wrapper = shallow(
-      <ExpandedStoryDescription {...defaultProps()} story={story} />
-    );
+    const { container } = renderComponent(props);
 
-    expect(wrapper).toExist();
+    expect(container).toBeInTheDocument();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_estimate_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_estimate_spec.js
@@ -1,66 +1,60 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryEstimate from 'components/story/ExpandedStory/ExpandedStoryEstimate';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryEstimate />', () => {
-  const defaultProps = () => ({
-    story: {},
-    project: {},
-    onEdit: vi.fn(),
-    disabled: false,
-  });
+  const renderComponent = props => {
+    const defaultProps = {
+      story: {},
+      project: {},
+      onEdit: vi.fn(),
+      disabled: false,
+    };
+
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryEstimate {...mergedProps} />);
+  };
 
   it("renders component with 'Fibonacci' point scale in select", () => {
-    const project = { pointValues: [1, 2, 3, 5, 8] };
-    const story = { estimate: null, _editing: { storyType: 'feature' } };
+    const props = {
+      story: { estimate: null, _editing: { storyType: 'feature' } },
+      project: { pointValues: [1, 2, 3, 5, 8] },
+    };
 
-    const wrapper = shallow(
-      <ExpandedStoryEstimate
-        {...defaultProps()}
-        project={project}
-        story={story}
-      />
-    );
-    const select = wrapper.find('select').text();
+    const { container } = renderComponent(props);
+    const select = container.querySelector('select');
 
-    project.pointValues.forEach(value => {
-      expect(select).toContain(value);
+    props.project.pointValues.forEach(value => {
+      expect(select).toHaveTextContent(value);
     });
   });
 
   it("renders component with 'Powers of two' point scale in select", () => {
-    const project = { pointValues: [1, 2, 4, 8] };
-    const story = { estimate: null, _editing: { storyType: 'feature' } };
+    const props = {
+      story: { estimate: null, _editing: { storyType: 'feature' } },
+      project: { pointValues: [1, 2, 4, 8] },
+    };
 
-    const wrapper = shallow(
-      <ExpandedStoryEstimate
-        {...defaultProps()}
-        project={project}
-        story={story}
-      />
-    );
-    const select = wrapper.find('select').text();
+    const { container } = renderComponent(props);
+    const select = container.querySelector('select');
 
-    project.pointValues.forEach(value => {
-      expect(select).toContain(value);
+    props.project.pointValues.forEach(value => {
+      expect(select).toHaveTextContent(value);
     });
   });
 
   it("renders component with 'Linear' point scale in select", () => {
-    const project = { pointValues: [1, 2, 3, 4, 5] };
-    const story = { estimate: null, _editing: { storyType: 'feature' } };
+    const props = {
+      story: { estimate: null, _editing: { storyType: 'feature' } },
+      project: { pointValues: [1, 2, 3, 4, 5] },
+    };
 
-    const wrapper = shallow(
-      <ExpandedStoryEstimate
-        {...defaultProps()}
-        project={project}
-        story={story}
-      />
-    );
-    const select = wrapper.find('select').text();
+    const { container } = renderComponent(props);
+    const select = container.querySelector('select');
 
-    project.pointValues.forEach(value => {
-      expect(select).toContain(value);
+    props.project.pointValues.forEach(value => {
+      expect(select).toHaveTextContent(value);
     });
   });
 
@@ -69,48 +63,40 @@ describe('<ExpandedStoryEstimate />', () => {
 
     pointValues.forEach(value => {
       it(`sets the select defaultValue as ${value}`, () => {
-        const project = { pointValues };
-        const story = {
-          _editing: {
-            storyType: 'feature',
-            estimate: value,
+        const props = {
+          project: { pointValues },
+          story: {
+            _editing: {
+              storyType: 'feature',
+              estimate: value,
+            },
           },
         };
 
-        const wrapper = shallow(
-          <ExpandedStoryEstimate
-            {...defaultProps()}
-            project={project}
-            story={story}
-          />
-        );
-        const select = wrapper.find('select');
+        const { container } = renderComponent(props);
+        const select = container.querySelector('select');
 
-        expect(select.prop('value')).toBe(value);
+        expect(select).toHaveValue(value.toString());
       });
     });
   });
 
   describe('When story.estimate is null', () => {
     it('sets the select defaultValue as null', () => {
-      const project = { pointValues: [1, 2, 3, 4, 5] };
-      const story = {
-        _editing: {
-          estimate: '',
-          storyType: 'bug',
+      const props = {
+        project: { pointValues: [1, 2, 3, 4, 5] },
+        story: {
+          _editing: {
+            estimate: '',
+            storyType: 'bug',
+          },
         },
       };
 
-      const wrapper = shallow(
-        <ExpandedStoryEstimate
-          {...defaultProps()}
-          project={project}
-          story={story}
-        />
-      );
-      const select = wrapper.find('select');
+      const { container } = renderComponent(props);
+      const select = container.querySelector('select');
 
-      expect(select.prop('value')).toBe('');
+      expect(select).toHaveValue('');
     });
   });
 
@@ -119,55 +105,40 @@ describe('<ExpandedStoryEstimate />', () => {
       const notFeatureTypes = ['bug', 'release', 'chore'];
 
       it('disables estimate select', () => {
-        const project = { pointValues: [1, 2, 3, 4, 5] };
-
         notFeatureTypes.forEach(type => {
-          const story = { _editing: { storyType: type } };
-          const wrapper = shallow(
-            <ExpandedStoryEstimate
-              {...defaultProps()}
-              project={project}
-              story={story}
-            />
-          );
+          const props = {
+            project: { pointValues: [1, 2, 3, 4, 5] },
+            story: { _editing: { storyType: type } },
+          };
 
-          const select = wrapper.find('select');
+          const { container } = renderComponent(props);
+          const select = container.querySelector('select');
 
-          expect(select.prop('disabled')).toBe(true);
+          expect(select).toBeDisabled();
         });
       });
     });
 
     describe('to a feature', () => {
-      const project = { pointValues: [1, 2, 3, 4, 5] };
-      const story = { _editing: { storyType: 'feature' } };
+      const props = {
+        project: { pointValues: [1, 2, 3, 4, 5] },
+        story: { _editing: { storyType: 'feature' } },
+        disabled: false,
+      };
 
       it("doesn't disable estimate select when disabled prop is false", () => {
-        const wrapper = shallow(
-          <ExpandedStoryEstimate
-            {...defaultProps()}
-            project={project}
-            story={story}
-            disabled={false}
-          />
-        );
-        const select = wrapper.find('select');
+        const { container } = renderComponent(props);
+        const select = container.querySelector('select');
 
-        expect(select.prop('disabled')).not.toBe(true);
+        expect(select).not.toBeDisabled();
       });
 
       describe('when component is disabled', () => {
         it('disables estimate select when disabled prop is true', () => {
-          const wrapper = shallow(
-            <ExpandedStoryEstimate
-              {...defaultProps()}
-              project={project}
-              story={story}
-              disabled={true}
-            />
-          );
-          const select = wrapper.find('select');
-          expect(select.prop('disabled')).toBe(true);
+          const { container } = renderComponent({ ...props, disabled: true });
+          const select = container.querySelector('select');
+
+          expect(select).toBeDisabled();
         });
       });
     });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_history_location_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_history_location_spec.js
@@ -67,7 +67,6 @@ describe('<ExpandedStoryHistoryLocation />', () => {
       };
 
       const { container } = renderComponent(props);
-      // TODO: fix this
       const copyIdButton = container.querySelector(
         `[data-clipboard-text="#42"]`
       );

--- a/spec/javascripts/components/story/expanded_story/expanded_story_labels_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_labels_spec.js
@@ -95,8 +95,7 @@ describe('<ExpandedStoryLabels />', () => {
 
   describe('<ReactTags />', () => {
     it('renders with the right tags prop', () => {
-      const { wrapper, labels, reactTags } = setup();
-      screen.debug();
+      const { wrapper, labels } = setup();
       const renderedLabelElements = wrapper.querySelectorAll(
         '.react-tags__selected-tag-name'
       );

--- a/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_notes_spec.js
@@ -70,16 +70,16 @@ describe('<ExpandedStoryNotes />', () => {
   });
 
   describe('when component is enabled', () => {
+    const onCreateSpy = vi.fn();
+    const props = {
+      onCreate: onCreateSpy,
+      onDelete,
+      disabled: false,
+    };
+    const change = 'newNote';
+
     describe('when user create a new note', () => {
       it('triggers the onCreate callback passing the note', () => {
-        const onCreateSpy = vi.fn();
-        const change = 'newNote';
-        const props = {
-          onCreate: onCreateSpy,
-          onDelete,
-          disabled: false,
-        };
-
         const { container } = renderComponent(props);
         const textArea = container.querySelector('.create-note-text');
         const button = container.querySelector('.create-note-button input');
@@ -93,12 +93,6 @@ describe('<ExpandedStoryNotes />', () => {
     });
 
     it('disables the add note button if text area is empty', () => {
-      const props = {
-        onCreate,
-        onDelete,
-        disabled: false,
-      };
-
       const { container } = renderComponent(props);
       const textArea = container.querySelector('.create-note-text');
       const button = container.querySelector('.create-note-button input');
@@ -109,16 +103,14 @@ describe('<ExpandedStoryNotes />', () => {
   });
 
   describe('when component is disabled', () => {
-    it('does not render a create note button', () => {
-      const notes = [{ id: 0, note: 'foo' }];
-      const story = newStory(notes);
-      const props = {
-        onCreate,
-        onDelete,
-        disabled: true,
-        story,
-      };
+    const props = {
+      onCreate,
+      onDelete,
+      disabled: true,
+      story: newStory([{ id: 0, note: 'foo' }]),
+    };
 
+    it('does not render a create note button', () => {
       const { container } = renderComponent(props);
       const createNoteButton = container.querySelector('.create-note-button');
 
@@ -126,15 +118,6 @@ describe('<ExpandedStoryNotes />', () => {
     });
 
     it('does not render a create note text area', () => {
-      const notes = [{ id: 0, note: 'foo' }];
-      const story = newStory(notes);
-      const props = {
-        onCreate,
-        onDelete,
-        disabled: true,
-        story,
-      };
-
       const { container } = renderComponent(props);
 
       expect(container.querySelector('.create-note-text')).toBeNull();
@@ -142,15 +125,7 @@ describe('<ExpandedStoryNotes />', () => {
 
     describe('when there are no notes', () => {
       it('renders nothing', () => {
-        const story = newStory();
-        const props = {
-          onCreate,
-          onDelete,
-          disabled: true,
-          story,
-        };
-
-        const { container } = renderComponent(props);
+        const { container } = renderComponent({ ...props, story: newStory() });
 
         expect(container.innerHTML).toBe('');
       });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_owned_by_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_owned_by_spec.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryOwnedBy from 'components/story/ExpandedStory/ExpandedStoryOwnedBy';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryOwnedBy />', () => {
-  const setup = propOverrides => {
-    const defaultProps = () => ({
+  const renderComponent = props => {
+    const defaultProps = {
       users: [
         { id: 1, name: 'foo' },
         { id: 2, name: 'bar' },
@@ -12,17 +12,16 @@ describe('<ExpandedStoryOwnedBy />', () => {
       story: { _editing: { ownedById: '' } },
       onEdit: vi.fn(),
       disabled: false,
-      ...propOverrides,
-    });
+    };
 
-    const wrapper = shallow(<ExpandedStoryOwnedBy {...defaultProps()} />);
+    const mergedProps = { ...defaultProps, ...props };
 
-    return { wrapper };
+    return renderWithProviders(<ExpandedStoryOwnedBy {...mergedProps} />);
   };
 
   it('renders properly', () => {
-    const { wrapper } = setup();
+    const { container } = renderComponent();
 
-    expect(wrapper).toExist();
+    expect(container).toBeInTheDocument();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_release/expanded_story_release_date_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_release/expanded_story_release_date_spec.js
@@ -1,23 +1,30 @@
-import React from 'react';
-import { mount } from 'enzyme';
+import { screen } from '@testing-library/react';
 import ExpandedStoryReleaseDate from 'components/story/ExpandedStory/ExpandedStoryRelease/ExpandedStoryReleaseDate';
+import React from 'react';
 import storyFactory from '../../../../support/factories/storyFactory';
+import { renderWithProviders } from '../../../setupRedux';
 
 describe('<ExpandedStoryReleaseDate />', () => {
-  const defaultProps = () => ({
-    story: {
-      ...storyFactory(),
-      _editing: storyFactory({ releaseDate: null }),
-    },
-    disabled: false,
-    onEdit: vi.fn(),
-  });
+  const renderComponent = props => {
+    const defaultProps = {
+      story: {
+        ...storyFactory(),
+        _editing: storyFactory({ releaseDate: null }),
+      },
+      disabled: false,
+      onEdit: vi.fn(),
+    };
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryReleaseDate {...mergedProps} />);
+  };
 
   it('renders component title', () => {
-    const wrapper = mount(<ExpandedStoryReleaseDate {...defaultProps()} />);
+    renderComponent();
 
-    expect(wrapper.text()).toContain(
+    const releaseText = screen.getByText(
       I18n.t('activerecord.attributes.story.release_date')
     );
+    expect(releaseText).toBeInTheDocument();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_requested_by_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_requested_by_spec.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryRequestedBy from 'components/story/ExpandedStory/ExpandedStoryRequestedBy';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryRequestBy />', () => {
-  const setup = propOverrides => {
-    const defaultProps = () => ({
+  const renderComponent = props => {
+    const defaultProps = {
       users: [
         { id: 1, name: 'foo' },
         { id: 2, name: 'bar' },
@@ -12,16 +12,16 @@ describe('<ExpandedStoryRequestBy />', () => {
       story: { _editing: { requestedById: 1 } },
       onEdit: vi.fn(),
       disabled: false,
-      ...propOverrides,
-    });
+    };
 
-    const wrapper = shallow(<ExpandedStoryRequestedBy {...defaultProps()} />);
-    return { wrapper };
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryRequestedBy {...mergedProps} />);
   };
 
   it('renders properly', () => {
-    const { wrapper } = setup();
+    const { container } = renderComponent();
 
-    expect(wrapper).toExist();
+    expect(container).toBeInTheDocument();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_section_spec.jsx
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_section_spec.jsx
@@ -1,41 +1,50 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStorySection from 'components/story/ExpandedStory/ExpandedStorySection';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStorySection />', () => {
+  const renderComponent = props => {
+    const defaultProps = {};
+
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStorySection {...mergedProps} />);
+  };
+
   it('renders section-title with the right text', () => {
-    const title = 'my title';
-    const children = 'children';
+    const props = {
+      title: 'my title',
+      children: 'children',
+    };
 
-    const wrapper = shallow(
-      <ExpandedStorySection title={title} children={children} />
-    );
+    const { container } = renderComponent(props);
+    const title = container.querySelector('.Story__section-title');
 
-    expect(wrapper.find('.Story__section-title').text()).toContain(title);
+    expect(title).toHaveTextContent(props.title);
   });
 
   it('renders with the right identifier className', () => {
-    const identifier = 'content';
-    const children = 'children';
+    const props = {
+      title: 'title',
+      identifier: 'content',
+      children: 'children',
+    };
 
-    const wrapper = shallow(
-      <ExpandedStorySection
-        title="title"
-        identifier={identifier}
-        children={children}
-      />
-    );
+    const { container } = renderComponent(props);
+    const section = container.querySelector('.Story__section__content');
 
-    expect(wrapper.find(`.Story__section__${identifier}`)).toExist();
+    expect(section).toHaveClass(`Story__section__${props.identifier}`);
   });
 
   it('renders children', () => {
-    const children = <div>{'children'}</div>;
+    const props = {
+      title: 'title',
+      children: <div>{'children'}</div>,
+    };
 
-    const wrapper = shallow(
-      <ExpandedStorySection title="title">{children}</ExpandedStorySection>
-    );
+    const { container } = renderComponent(props);
+    const children = container.querySelector('.Story__section__content');
 
-    expect(wrapper).toContainReact(children);
+    expect(children).toHaveTextContent('children');
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_spec.js
@@ -47,7 +47,6 @@ describe('<ExpandedStory />', () => {
       const releaseTitle = screen.getByText(
         I18n.t('activerecord.attributes.story.release_date')
       );
-      console.log(releaseTitle.innerHTML);
 
       expect(releaseTitle).toBeInTheDocument();
     });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_state_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_state_spec.js
@@ -162,7 +162,7 @@ describe('<ExpandedStoryState />', () => {
   });
 
   describe('when component is disabled', () => {
-    it('select field is editable', () => {
+    it('select field is disabled', () => {
       const onEditSpy = vi.fn();
       const props = {
         story: { state: 'started', _editing: { state: 'started' } },
@@ -178,7 +178,7 @@ describe('<ExpandedStoryState />', () => {
   });
 
   describe('when component is enabled', () => {
-    it('select field is enabled', () => {
+    it('select field is editable', () => {
       const onEditSpy = vi.fn();
       const props = {
         story: { state: 'started', _editing: { state: 'started' } },

--- a/spec/javascripts/components/story/expanded_story/expanded_story_title_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_title_spec.js
@@ -1,60 +1,75 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import { fireEvent } from '@testing-library/react';
 import ExpandedStoryTitle from 'components/story/ExpandedStory/ExpandedStoryTitle';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryTitle />', () => {
-  const setup = propOverrides => {
-    const defaultProps = () => ({
+  const renderComponent = props => {
+    const defaultProps = {
       story: { _editing: { title: 'foo' } },
       onEdit: vi.fn(),
       disabled: false,
-      ...propOverrides,
-    });
+    };
+    const mergedProps = { ...defaultProps, ...props };
 
-    const wrapper = shallow(<ExpandedStoryTitle {...defaultProps()} />);
-    const input = wrapper.find('input');
-
-    return { wrapper, input };
+    return renderWithProviders(<ExpandedStoryTitle {...mergedProps} />);
   };
 
   it('renders properly', () => {
-    const { wrapper } = setup();
+    const { container } = renderComponent();
 
-    expect(wrapper).toExist();
+    expect(container).toBeInTheDocument();
   });
 
   describe('input element', () => {
     it('has value equals to story title', () => {
-      const story = { _editing: { title: 'bar' } };
+      const props = {
+        story: { _editing: { title: 'bar' } },
+      };
 
-      const { input } = setup({ story });
+      const { container } = renderComponent(props);
+      const input = container.querySelector('input');
 
-      expect(input.prop('value')).toBe(story._editing.title);
+      expect(input.value).toBe(props.story._editing.title);
     });
 
     it('calls onEdit with the right params', () => {
       const mockOnEdit = vi.fn();
       const eventValue = 'foobar';
-      const { input } = setup({ onEdit: mockOnEdit });
+      const props = {
+        onEdit: mockOnEdit,
+      };
 
-      input.simulate('change', { target: { value: eventValue } });
+      const { container } = renderComponent(props);
+      const input = container.querySelector('input');
+      fireEvent.change(input, { target: { value: eventValue } });
 
       expect(mockOnEdit).toHaveBeenCalledWith(eventValue);
     });
 
     describe('when the component is enabled', () => {
       it('should not be read-only', () => {
-        const { input } = setup({ disabled: false });
+        const props = {
+          disabled: false,
+        };
 
-        expect(input.prop('readOnly')).toBe(false);
+        const { container } = renderComponent(props);
+        const input = container.querySelector('input');
+
+        expect(input.readOnly).toBe(false);
       });
     });
 
     describe('when component is disabled', () => {
       it('should be read-only', () => {
-        const { input } = setup({ disabled: true });
+        const props = {
+          disabled: true,
+        };
 
-        expect(input.prop('readOnly')).toBe(true);
+        const { container } = renderComponent(props);
+        const input = container.querySelector('input');
+
+        expect(input.readOnly).toBe(true);
       });
     });
   });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_tooltip_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_tooltip_spec.js
@@ -1,10 +1,13 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryTooltip from 'components/story/ExpandedStory/ExpandedStoryToolTip';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryTooltip />', () => {
   it('renders <Popover />', () => {
-    const wrapper = shallow(<ExpandedStoryTooltip text="any text" />);
-    expect(wrapper.find('Popover').exists()).toBe(true);
+    const { container } = renderWithProviders(<ExpandedStoryTooltip />);
+
+    const tooltip = container.querySelector('.infoToolTip');
+
+    expect(tooltip).toBeInTheDocument();
   });
 });

--- a/spec/javascripts/components/story/expanded_story/expanded_story_type_spec.js
+++ b/spec/javascripts/components/story/expanded_story/expanded_story_type_spec.js
@@ -1,44 +1,50 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ExpandedStoryType from 'components/story/ExpandedStory/ExpandedStoryType';
 import { types } from 'models/beta/story';
+import React from 'react';
+import { renderWithProviders } from '../../setupRedux';
 
 describe('<ExpandedStoryType />', () => {
-  const setup = propOverrides => {
+  const renderComponent = props => {
     const defaultProps = {
       onEdit: vi.fn(),
       story: { _editing: { storyType: 'feature' } },
       disabled: false,
-      ...propOverrides,
     };
-    const wrapper = shallow(<ExpandedStoryType {...defaultProps} />);
-    const select = wrapper.find('select');
 
-    return { wrapper, select };
+    const mergedProps = { ...defaultProps, ...props };
+
+    return renderWithProviders(<ExpandedStoryType {...mergedProps} />);
   };
 
   types.forEach(type => {
     it(`sets defaultValue as ${type} in select`, () => {
-      const story = { _editing: { storyType: type } };
-      const { select } = setup({ story });
+      const props = {
+        story: { _editing: { storyType: type } },
+      };
 
-      expect(select.prop('value')).toBe(type);
+      const { container } = renderComponent(props);
+      const select = container.querySelector('select');
+
+      expect(select.value).toBe(type);
     });
   });
 
   describe('when component is not disabled', () => {
     it('select field is editable', () => {
-      const { select } = setup();
+      const { container } = renderComponent();
+      const select = container.querySelector('select');
 
-      expect(select.prop('disabled')).toBe(false);
+      expect(select).toBeInTheDocument();
+      expect(select).not.toBeDisabled();
     });
   });
 
   describe('when component is disabled', () => {
     it('select field is disabled', () => {
-      const { select } = setup({ disabled: true });
+      const { container } = renderComponent({ disabled: true });
+      const select = container.querySelector('select');
 
-      expect(select.prop('disabled')).toBe(true);
+      expect(select).toBeDisabled();
     });
   });
 });


### PR DESCRIPTION
## What this PR do ?
Migrate unit tests in `components/story/expanded_story` from Enzyme to testing-library

## Related Issues
#908 

## Screenshots (if applicable)
N/A

## Additional Notes (if any)
Working with @wrspada02 , merged some of his upstream changes into it before opening PR