### PR TITLE
Remove unnecessary sleep in tests

### DIFF
--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -136,7 +136,6 @@ describe 'Teams', js: true do
 
       it 'successfully uncharving the team' do
         visit teams_path
-        sleep 0.5
 
         click_link 'Unarchive'
 
@@ -145,7 +144,6 @@ describe 'Teams', js: true do
 
       it 'moves the archived team to select team section' do
         visit teams_path
-        sleep 0.5
 
         click_link 'Unarchive'
 


### PR DESCRIPTION
## What this PR do ?
<!--Give a brief description of the changes proposed in this PR.-->

Capybara waits until the target elements to appear by default. 
So, remove unnecessary `sleep` method to reduce CI time (a bit).

> If the driver is capable of executing JavaScript, this method will wait for a set amount of time and continuously retry finding the element until either the element is found or the time expires. The length of time this method will wait is controlled through [default_max_wait_time](https://rubydoc.info/github/jnicklas/capybara/Capybara#configure-class_method).

refs:
https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Actions#click_link-instance_method

## Related Issues
<!--Mention any related issues fixed or addressed by this PR.-->

No

## Screenshots (if applicable)
<!--Include screenshots or images showcasing the changes made.-->

No

## Additional Notes (if any)
<!--Any additional information or context that might be helpful for reviewers.-->

Also about default sleep is mentioned here https://github.com/teamcapybara/capybara?tab=readme-ov-file#asynchronous-javascript-ajax-and-friends