### PR TITLE
Fix: Broken CI tests 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ end
 group :test do
   gem 'rails-controller-testing'
   gem 'capybara'
+  gem 'capybara-lockstep'
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.2.3)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
@@ -602,6 +607,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.4.0)
   bullet
   capybara
+  capybara-lockstep
   capybara-screenshot
   chartkick
   chronic

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,8 @@
   <span class="navbar-brand"><%= t('login') %></span>
 <% end %>
 
+<%= capybara_lockstep if defined?(Capybara::Lockstep) %>
+
 <div class="container">
   <div class="row">
 

--- a/spec/features/confirmations_spec.rb
+++ b/spec/features/confirmations_spec.rb
@@ -1,5 +1,4 @@
 require 'feature_helper'
-
 describe 'Confirmations' do
   let(:team) { create(:team) }
 


### PR DESCRIPTION
## What this PR do ?
<!--Give a brief description of the changes proposed in this PR.-->
- Our CI had some broken tests due to the ChromeDriver version in the Ubuntu image. This is a [known issue](https://github.com/teamcapybara/capybara/issues/2800) for the Capybara gem.
The community is suggesting a gem that syncs Capybara commands with the JS: https://github.com/makandra/capybara-lockstep